### PR TITLE
build(format): integrate clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+BasedOnStyle: WebKit
+Language: Cpp
+ColumnLimit: 100
+PointerBindsToType: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterCaseLabel: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: true
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
+AlignAfterOpenBracket: true
+AlwaysBreakTemplateDeclarations: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,6 @@ jobs:
     steps:
       - name: Checkout the respository
         uses: actions/checkout@v3
+      - run: make format && git diff --quiet
       - run: TOOLS_PATH=/home/ubuntu/ti make
       - run: make cppcheck  

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ CC = $(MSPGCC_BIN_DIR)/msp430-elf-gcc
 RM = rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
+FORMAT = clang-format
 
 # Files
 TARGET = $(BIN_DIR)/blink
@@ -43,7 +44,7 @@ $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 # Phonies
-.PHONY: all clean flash cppcheck
+.PHONY: all clean flash cppcheck format
 
 all: $(TARGET)
 
@@ -62,3 +63,6 @@ cppcheck:
 	--suppress=missingIncludeSystem		\
 	--suppress=unmatchedSuppression		\
 	$(SOURCES)				\
+
+format:
+	@$(FORMAT) -i $(SOURCES)

--- a/src/main.c
+++ b/src/main.c
@@ -3,13 +3,13 @@
 int main(void)
 {
     volatile unsigned int i;
-    WDTCTL = WDTPW + WDTHOLD;                 // Stop watchdog timer
-    P1DIR |= 0x01;                            // Set P1.0 to output direction
+    WDTCTL = WDTPW + WDTHOLD; // Stop watchdog timer
+    P1DIR |= 0x01; // Set P1.0 to output direction
 
-    while(1)
-    {
-        P1OUT ^= 0x01;                       // Toggle P1.0 using exclusive-OR
+    while (1) {
+        P1OUT ^= 0x01; // Toggle P1.0 using exclusive-OR
 
-        for (i=20000; i>0; i--);
-  }
+        for (i = 20000; i > 0; i--)
+            ;
+    }
 }

--- a/tools/dockerfile
+++ b/tools/dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Install necessary packages
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update  \
-    && apt-get install -y wget bzip2 make unzip cppcheck
+    && apt-get install -y wget bzip2 make unzip cppcheck clang-format
 
 # Create a non-root user named "ubuntu"
 # But put in root group since GitHub actions needs permissions


### PR DESCRIPTION
Update clang-format file. Add clang-format to docker set-up. Add a format check to ci.yml. Insert format rule in Makefile.