### PR TITLE
feature(assert): assert handler and led driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ TARGET = $(BUILD_DIR)/$(TARGET_NAME)_exe
 
 SOURCES_W_HEADERS = 	\
 	src/drivers/io.c	\
-	src/drivers/mcu_init.c
+	src/drivers/mcu_init.c \
+	src/drivers/led.c	\
+	src/common/assert_handler.c	
 #	src/drivers/uart.c	\
 	src/drivers/i2c.c	\
 	src/app/drive.c		\

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CPPCHECK_FLAGS = \
 # Flags
 MCU = msp430g2553
 WFLAGS = -Wall -Wextra -Werror -Wshadow
-CFLAGS = -mmcu=$(MCU) $(WFLAGS) $(addprefix -I , $(INCLUDE_DIRS)) $(DEFINES) -Og -g
+CFLAGS = -mmcu=$(MCU) $(WFLAGS) $(addprefix -I , $(INCLUDE_DIRS)) $(DEFINES) -Og -g -fshort-enums
 LDFLAGS = -mmcu=$(MCU) $(DEFINES) $(addprefix -L , $(LIB_DIRS))
 
 # Build

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -1,0 +1,37 @@
+#include "assert_handler.h"
+#include "defines.h"
+#include <msp430.h>
+
+/* The TI compiler provides supoort for calling an opcode.
+ * Write __op_code(0x4343) to trigger a breakpoint with the TI toolchain.
+ * This corresponds to the assembly instruction "CLR.B R3" that is
+ * needed to trigger a breakpoint in the GCC toolchain.
+ */
+#define BREAKPOINT __asm volatile("CLR.B R3");
+
+void assert_handler(void)
+{
+    // TODO: Turn off motors
+    // TODO: Trace console
+    // Breakpoint
+    BREAKPOINT
+
+    // Configure TEST LED pin on LAUNCHPAD
+    P1SEL &= ~(BIT0);
+    P1SEL2 &= ~(BIT0);
+    P1DIR |= BIT0;
+    P1REN &= ~(BIT0);
+
+    // COnfigure TEST LED pin on JR
+    P2SEL &= ~(BIT6);
+    P2SEL2 &= ~(BIT6);
+    P2DIR |= (BIT6);
+    P2REN &= ~(BIT6);
+
+    while (1) {
+        // Blink LED on both targets, in case wrong target was flashed
+        P1OUT ^= BIT0;
+        P2OUT ^= BIT6;
+        BUSY_WAIT_ms(2500);
+    };
+}

--- a/src/common/assert_handler.h
+++ b/src/common/assert_handler.h
@@ -1,0 +1,14 @@
+#ifndef ASSERT_HANDLER_H
+
+// Assert implementation suitable for a microcontroller
+
+#define ASSERT(expression)                                                                         \
+    do {                                                                                           \
+        if (!(expression)) {                                                                       \
+            assert_handler();                                                                      \
+        }                                                                                          \
+    } while (0);
+
+void assert_handler(void);
+
+#endif

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -4,4 +4,8 @@
 #define UNUSED(x) (void)(x)
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
 
+// TODO : Change clock rate from 1 MHz to 16 MHz
+#define CYCLES_1MHZ (1000000u)
+#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)
+#define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
 #endif

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -3,6 +3,7 @@
 
 #include <msp430.h>
 #include <stdint.h>
+#include <assert.h>
 
 #if defined(LAUNCHPAD)
 #define IO_PORT_CNT (2u)
@@ -12,6 +13,7 @@
 #define IO_PIN_CNT_PER_PORT (8u)
 
 // io generic enum values: [Zeros (11-bits) | Port (2-bits) | pin (3-bits)]
+static_assert(sizeof(io_generic_e) == 1, "Unexpected size, missing -fshort-enums flag?");
 #define IO_PORT_OFFSET (3u)
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0x7u)

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -187,6 +187,27 @@ void io_configure(io_e io, const struct io_config *config)
     io_set_resistor(io, config->resistor);
 }
 
+void io_get_current_config(io_e io, struct io_config *current_config)
+{
+    // Reads the pin's configuration data
+    const uint8_t port = io_port(io);
+    const uint8_t pin = io_pin_bit(io);
+    const uint8_t sel1 = *port_sel1_regs[port] & pin;
+    const uint8_t sel2 = *port_sel2_regs[port] & pin;
+    // Returns configuration in the user interface format
+    current_config->select = (io_sel_e)((sel2 << 1) | sel1);
+    current_config->resistor = (io_res_e)(*port_ren_regs[port] & pin);
+    current_config->dir = (io_dir_e)(*port_dir_regs[port] & pin);
+    current_config->out = (io_out_e)(*port_out_regs[port] & pin);
+}
+
+bool io_config_compare(const struct io_config *cfg1, const struct io_config *cfg2)
+{
+    // Compare each field and if any are not the same return false
+    return (cfg1->select == cfg2->select) && (cfg1->resistor == cfg2->resistor)
+        && (cfg1->dir == cfg2->dir) && (cfg1->out == cfg2->out);
+}
+
 void io_set_select(io_e io, io_sel_e select)
 {
     const uint8_t port = io_port(io);

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -1,5 +1,8 @@
 #ifndef IO_H
 #define IO_H
+
+#include <stdbool.h>
+
 /* IO pin handling including pinmapping, initialization, and configuration.
  * This wraps the lower register defines provided in the headers from
  * Texas Instruments
@@ -70,8 +73,8 @@ typedef enum {
 } io_sel_e;
 
 typedef enum {
-    IO_DIR_OUTPUT,
     IO_DIR_INPUT,
+    IO_DIR_OUTPUT,
 } io_dir_e;
 
 typedef enum {
@@ -101,6 +104,8 @@ struct io_config
 /********************** FUNC ************************/
 void io_init(void);
 void io_configure(io_e io, const struct io_config *config);
+void io_get_current_config(io_e io, struct io_config *current_config);
+bool io_config_compare(const struct io_config *cfg1, const struct io_config *cfg2);
 void io_set_select(io_e io, io_sel_e select);
 void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_res_e resistor);

--- a/src/drivers/led.c
+++ b/src/drivers/led.c
@@ -1,0 +1,30 @@
+#include "led.h"
+#include "../common/defines.h"
+#include "../common/assert_handler.h"
+#include "io.h"
+#include <stdbool.h>
+
+static const struct io_config led_config = {
+    .select = IO_SEL_GPIO, .resistor = IO_RES_DIS, .dir = IO_DIR_OUTPUT, .out = IO_OUT_LOW
+};
+
+static bool initialized = false;
+void led_init(void)
+{
+    ASSERT(!initialized);
+    struct io_config current_config;
+    io_get_current_config(IO_TEST_LED, &current_config);
+    ASSERT(io_config_compare(&led_config, &current_config))
+    initialized = true;
+}
+
+void led_set(led_e led, led_state_e state)
+{
+    ASSERT(initialized);
+    const io_out_e out = (state == LED_ON) ? IO_OUT_HIGH : IO_OUT_LOW;
+    switch (led) {
+    case LED_TEST:
+        io_set_out(IO_TEST_LED, out);
+        break;
+    }
+}

--- a/src/drivers/led.h
+++ b/src/drivers/led.h
@@ -1,0 +1,16 @@
+#ifndef LED_H
+
+// simple driver configuring GPIO pins that are connected to LEDS
+
+typedef enum {
+    LED_TEST
+} led_e;
+
+typedef enum {
+    LED_OFF,
+    LED_ON
+} led_state_e;
+void led_init(void);
+void led_set(led_e led, led_state_e state);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,28 +1,34 @@
 #include <msp430.h>
 #include "drivers/io.h"
 #include "drivers/mcu_init.h"
+#include "drivers/led.h"
+#include "common/assert_handler.h"
+#include "common/defines.h"
+
 static void test_setup(void)
 {
     mcu_init();
 }
-
+/*
 // TODO: Put in test.c
+static void test_assert(void)
+{
+    test_setup();
+    ASSERT(0);
+}
 
 static void test_blink_led(void)
 {
     test_setup();
-    const struct io_config led_config = {
-        .dir = IO_DIR_OUTPUT, .select = IO_SEL_GPIO, .resistor = IO_RES_DIS, .out = IO_OUT_LOW
-    };
-    io_configure(IO_TEST_LED, &led_config);
-    io_out_e out = IO_OUT_LOW;
+    led_init();
+    led_state_e led_state = LED_OFF;
     while (1) {
-        out = (out == IO_OUT_LOW) ? IO_OUT_HIGH : IO_OUT_LOW;
-        io_set_out(IO_TEST_LED, out);
-        __delay_cycles(2500000); // 2500 ms
+        led_state = (led_state == LED_ON) ? LED_OFF : LED_ON;
+        led_set(LED_TEST, led_state);
+        BUSY_WAIT_ms(250);
     }
 }
-/*
+
 static void test_launchpad_io_pins_output(void)
 {
     test_setup();
@@ -43,7 +49,7 @@ static void test_launchpad_io_pins_output(void)
         for (io_generic_e io = IO_10; io <= IO_27; io++)
         {
             io_set_out(io, IO_OUT_HIGH);
-            __delay_cycles(10000);
+            BUSY_WAIT_ms(100);
             io_set_out(io, IO_OUT_LOW);
         }
     }
@@ -52,11 +58,13 @@ static void test_launchpad_io_pins_output(void)
 * Configure all pins except pin 1.0 (test led) internal pull up resistors.
  * Verify by pulling each pin down in increasing order with an
  * external pull-down resistor. LED state changes when the right pin is
- * pulled doen. Oncce all pins have been cerified, the LED blinks continously.
-*
+ * pulled down. Oncce all pins have been cerified, the LED blinks continously.
+*/
 static void test_launchpad_io_pins_input(void)
 {
     test_setup();
+    led_init();
+
     const struct io_config input_config = {
         .select = IO_SEL_GPIO,
         .resistor = IO_RES_EN,
@@ -64,52 +72,40 @@ static void test_launchpad_io_pins_input(void)
         .out = IO_OUT_HIGH,
     };
 
-    // TODO: Replace with LED driver
-    const struct io_config led_config = {
-        .select = IO_SEL_GPIO,
-        .resistor = IO_RES_DIS,
-        .dir = IO_DIR_OUTPUT,
-        .out = IO_OUT_LOW,
-    };
-
-    // Configure test led and all other pins as inputs
-    const io_generic_e io_led = IO_10;
-
-    for (io_generic_e io = IO_10; io <= IO_27; io++) {
+    for (io_generic_e io = IO_11; io <= IO_27; io++) {
         io_configure(io, &input_config);
     }
 
-    io_configure(io_led, &led_config);
-
     // Test inputs
     for (io_generic_e io = IO_10; io <= IO_27; io++) {
-        if (io == io_led)
+        if (io == (io_generic_e)IO_TEST_LED)
             continue;
-        io_set_out(io_led, IO_OUT_HIGH);
+        led_set(LED_TEST, LED_ON);
         // wait for user to pull pin low
         while (io_get_input(io) == IO_IN_HIGH) {
-            __delay_cycles(100000); // 100 ms
+            BUSY_WAIT_ms(100); // 100 ms
         }
-        io_set_out(io_led, IO_OUT_LOW);
+        led_set(LED_TEST, LED_OFF);
         // Wait for user to disconnect
         while (io_get_input(io) == IO_IN_LOW) {
-            __delay_cycles(100000); // 100 ms
+            BUSY_WAIT_ms(100); // 100 ms
         }
     }
 
     // Blink LED when test is done
     while (1) {
-        io_set_out(io_led, IO_OUT_HIGH);
-        __delay_cycles(500000); // 500 ms
-        io_set_out(io_led, IO_OUT_LOW);
-        __delay_cycles(500000); // 500 ms
+        led_set(LED_TEST, LED_ON);
+        BUSY_WAIT_ms(500); // 500 ms
+        led_set(LED_TEST, LED_OFF);
+        BUSY_WAIT_ms(500); // 500 ms
     }
 }
-*/
+
 int main(void)
 {
-    test_blink_led();
-    // test_launchpad_io_pins_output();
-    // test_launchpad_io_pins_input();
+    // test_assert();
+    // test_blink_led();
+    //  test_launchpad_io_pins_output();
+    test_launchpad_io_pins_input();
     return 0;
 }


### PR DESCRIPTION
Create an assert handler to handle errors in the code. Add in breakpoint logic and blink the test LED with the msp430 header.

Create a driver to handle LED's. This will condense the code and make it more reusable.

Create BUSY_WAIT_ms() to improve readability.