### PR TITLE
build(make): Add Rules to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ RM = rm
 DEBUG = LD_LIBRARY_PATH=$(DEBUG_DRIVERS_DIR) $(DEBUG_BIN_DIR)/mspdebug
 CPPCHECK = cppcheck
 FORMAT = clang-format
+SIZE = $(MSPGCC_BIN_DIR)/msp430-elf-size
+READELF = $(MSPGCC_BIN_DIR)/msp430-elf-readelf
 
 # Files
 TARGET = $(BUILD_DIR)/bin/$(TARGET_HW)/$(TARGET_NAME)
@@ -113,7 +115,7 @@ $(OBJ_DIR)/%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 # Phonies
-.PHONY: all clean flash cppcheck format
+.PHONY: all clean flash cppcheck format size
 
 all: $(TARGET)
 
@@ -129,3 +131,10 @@ cppcheck:
 
 format:
 	@$(FORMAT) -i $(SOURCES) $(HEADERS)
+
+size: $(TARGET)
+	@$(SIZE) $(TARGET)
+
+symbols: $(TARGET)
+	# List symbols table sorted by size
+	@$(READELF) -s $(TARGET) | sort -n -k3

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -19,7 +19,7 @@ static_assert(sizeof(io_generic_e) == 1, "Unexpected size, missing -fshort-enums
 #define IO_PORT_MASK (0x3u << IO_PORT_OFFSET)
 #define IO_PIN_MASK (0x7u)
 
-static inline uint8_t io_port(io_e io)
+static uint8_t io_port(io_e io)
 {
     return (io & IO_PORT_MASK) >> IO_PORT_OFFSET;
 }
@@ -29,7 +29,7 @@ static inline uint8_t io_pin_idx(io_e io)
     return io & IO_PIN_MASK;
 }
 
-static inline uint8_t io_pin_bit(io_e io)
+static uint8_t io_pin_bit(io_e io)
 {
     return 1 << io_pin_idx(io);
 }


### PR DESCRIPTION
Add two new rules to the makefile for analyzing the total flash space used. msp430g2553 only has 16kB of FLASH, this must be kept in mind when programming. The GCC toolchain has elf-size and elf-readelf command to better understand how much space the code actually occupies.

Removed inline from some IO function to reduce the overall size of the program. May lead to more CPU cycles, but FLASH space is more important in this case.