### PR TITLE
feature(io): Enable Interrupts

### DIFF
--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -32,6 +32,6 @@ void assert_handler(void)
         // Blink LED on both targets, in case wrong target was flashed
         P1OUT ^= BIT0;
         P2OUT ^= BIT6;
-        BUSY_WAIT_ms(2500);
+        BUSY_WAIT_ms(500);
     };
 }

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -4,6 +4,7 @@
 #define UNUSED(x) (void)(x)
 #define SUPPRESS_UNUSED __attribute__((unused))
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))
+#define INTERRUPT_FUNCTION(vector) void __attribute__((interrupt(vector)))
 
 // TODO : Change clock rate from 1 MHz to 16 MHz
 #define CYCLES_1MHZ (1000000u)

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -9,6 +9,15 @@
  */
 
 /********************** ENUMS ************************/
+
+typedef enum {
+    IO_PORT1,
+    IO_PORT2,
+#if defined(JR)
+    IO_PORT3,
+#endif
+} io_port_e;
+
 // clang-format off
 typedef enum {
     IO_10, IO_11, IO_12, IO_13, IO_14, IO_15, IO_16, IO_17,
@@ -92,6 +101,11 @@ typedef enum {
     IO_IN_HIGH,
 } io_in_e;
 
+typedef enum {
+    IO_TRIGGER_RISING,
+    IO_TRIGGER_FALLING,
+} io_trigger_e;
+
 /********************** STRUCTS ************************/
 struct io_config
 {
@@ -111,5 +125,11 @@ void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_res_e resistor);
 void io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
+
+typedef void (*isr_function)(void);
+void io_configure_interrupt(io_e io, io_trigger_e trigger, isr_function isr);
+void io_deconfigure_interrupt(io_e io);
+void io_enable_interrupt(io_e io);
+void io_disable_interrupt(io_e io);
 
 #endif

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -15,4 +15,6 @@ void mcu_init(void)
     // Must stop watchdog first
     watchdog_stop();
     io_init();
+    // Enables globaly
+    _enable_interrupts();
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -105,6 +105,39 @@ static void test_launchpad_io_pins_input(void)
     }
 }
 
+SUPPRESS_UNUSED
+static void io_11_isr(void)
+{
+    led_set(LED_TEST, LED_ON);
+}
+
+SUPPRESS_UNUSED
+static void io_20_isr(void)
+{
+    led_set(LED_TEST, LED_OFF);
+}
+
+SUPPRESS_UNUSED
+static void test_io_interrupt(void)
+{
+    test_setup();
+    const struct io_config input_config = {
+        .select = IO_SEL_GPIO,
+        .resistor = IO_RES_EN,
+        .dir = IO_DIR_INPUT,
+        .out = IO_OUT_HIGH,
+    };
+    io_configure(IO_11, &input_config);
+    io_configure(IO_20, &input_config);
+    led_init();
+    io_configure_interrupt(IO_11, IO_TRIGGER_FALLING, io_11_isr);
+    io_configure_interrupt(IO_20, IO_TRIGGER_FALLING, io_20_isr);
+    io_enable_interrupt(IO_11);
+    io_enable_interrupt(IO_20);
+    while (1);
+    
+}
+
 int main()
 {
     TEST();


### PR DESCRIPTION
Write the code enabling, configuring, triggering, and handling an interrupt input. This will help the microcontroller react to events in a timely manner instead of waiting or missing them completely, however increases the code complexity. Make sure to enable interrupts globally. Create a simple test to test the functionality. Increase blink speed in the assert handler.