### PR TITLE
fix(init): Increase Clock Speed

### DIFF
--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -8,6 +8,8 @@
 
 // TODO : Change clock rate from 1 MHz to 16 MHz
 #define CYCLES_1MHZ (1000000u)
-#define ms_TO_CYCLES(ms) ((CYCLES_1MHZ / 1000u) * ms)
+#define CYCLES_16MHZ (16u * CYCLES_1MHZ)
+#define CYCLES_PER_MS (CYCLES_16MHZ / 1000u)
+#define ms_TO_CYCLES(ms) (CYCLES_PER_MS * ms)
 #define BUSY_WAIT_ms(ms) (__delay_cycles(ms_TO_CYCLES(ms)))
 #endif

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -1,6 +1,21 @@
 #include "mcu_init.h"
 #include "io.h"
+#include "../common/assert_handler.h"
 #include <msp430.h>
+
+static void init_clocks(void)
+{
+    // Check to make sure calibration data has not been erased
+    ASSERT(CALBC1_1MHZ != 0xFF && CALBC1_16MHZ != 0xFF);
+
+    /* Configure internal oscillator to run at 16 MHz
+     * Used as a reference to produce a more stable DCO
+     */
+    BCSCTL1 |= CALBC1_16MHZ;
+
+    // Sets the clock rate of the digitally controlled oscillator (DCO)
+    DCOCTL |= CALDCO_16MHZ;
+}
 
 /* Watchdog is set by default
  * and repeatedly reset mcu if not turned off.
@@ -15,6 +30,7 @@ void mcu_init(void)
     // Must stop watchdog first
     watchdog_stop();
     io_init();
+    init_clocks();
     // Enables globaly
     _enable_interrupts();
 }


### PR DESCRIPTION
Increase clock speed to increase reaction time for robot. Does use more power, but is nothing to worry about for the sumo bot. Update BUSY_WAIT(ms) function to operate correctly with the faster clock.