### PR TITLE
feat(drivers): Implement ADC Driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/ir_remote.c  \
 	src/drivers/pwm.c		\
 	src/drivers/tb6612fng.c \
+	src/drivers/adc.c 	\
 	src/app/drive.c		\
 	src/common/assert_handler.c \
 	src/common/ring_buffer.c \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/pwm.c		\
 	src/drivers/tb6612fng.c \
 	src/drivers/adc.c 	\
+	src/drivers/qre1113.c	\
 	src/app/drive.c		\
 	src/common/assert_handler.c \
 	src/common/ring_buffer.c \

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,14 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/tb6612fng.c \
 	src/drivers/adc.c 	\
 	src/drivers/qre1113.c	\
-	src/app/drive.c		\
+	src/app/drive.c	\
+	src/app/line.c	\
 	src/common/assert_handler.c \
 	src/common/ring_buffer.c \
 	src/common/trace.c 	\
 	external/printf/printf.c 
 #	src/drivers/i2c.c	\
 	src/app/enemy.c		\
-	src/app/line.c
 
 ifndef TEST
 SOURCES = src/main.c \

--- a/src/app/line.c
+++ b/src/app/line.c
@@ -1,6 +1,54 @@
 #include "line.h"
+#include "../drivers/qre1113.h"
+#include "../common/assert_handler.h"
+#include <stdbool.h>
 
+// Based on the readings from the sensors when they are above the white line
+#define LINE_DETECTED_VOLTAGE_THRESHOLD (700u)
+
+static bool initialized = false;
 void line_init(void)
 {
-    // TODO: implement
+    ASSERT(!initialized);
+    qre1113_init();
+    initialized = true;
+}
+
+line_e line_get(void)
+{
+    struct qre1113_voltages voltages;
+    qre1113_get_voltages(&voltages);
+    const bool front_left = voltages.front_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool front_right = voltages.front_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_left = voltages.back_left < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    const bool back_right = voltages.back_right < LINE_DETECTED_VOLTAGE_THRESHOLD;
+    if (front_left) {
+        if (front_right) {
+            return LINE_FRONT;
+        } else if (back_left) {
+            return LINE_LEFT;
+        } else if (back_right) {
+            return LINE_DIAGONAL_LEFT;
+        } else {
+            return LINE_FRONT_LEFT;
+        }
+    } else if (front_right) {
+        if (back_right) {
+            return LINE_RIGHT;
+        } else if (back_left) {
+            return LINE_DIAGONAL_RIGHT;
+        } else {
+            return LINE_FRONT_RIGHT;
+        }
+    } else if (back_left) {
+        if (back_right) {
+            return LINE_BACK;
+        } else {
+            return LINE_BACK_LEFT;
+        }
+    } else if (back_right) {
+        return LINE_BACK_RIGHT;
+    } else {
+        return LINE_NONE;
+    }
 }

--- a/src/app/line.h
+++ b/src/app/line.h
@@ -1,6 +1,23 @@
 #ifndef LINE_H
 #define LINE_H
 
-void line_init(void);
+// Detect the boundary line of the circular sumobot platform
 
-#endif
+typedef enum {
+    LINE_NONE,
+    LINE_FRONT,
+    LINE_BACK,
+    LINE_LEFT,
+    LINE_RIGHT,
+    LINE_FRONT_LEFT,
+    LINE_FRONT_RIGHT,
+    LINE_BACK_LEFT,
+    LINE_BACK_RIGHT,
+    LINE_DIAGONAL_LEFT,
+    LINE_DIAGONAL_RIGHT
+} line_e;
+
+void line_init(void);
+line_e line_get(void);
+
+#endif // LINE_H

--- a/src/drivers/adc.c
+++ b/src/drivers/adc.c
@@ -1,0 +1,93 @@
+#include "adc.h"
+#include "io.h"
+#include "../common/assert_handler.h"
+#include "../common/defines.h"
+#include <msp430.h>
+#include <stdbool.h>
+
+/* Strategy:
+ * Setup ADC to sample a sequence of channels. Interrupt after the sequence
+ *  has been sampled and cache the sampled values, then start again. Access the
+ * latest values with a function call. Use DMA (DTC) and slow clock (ACLK) to
+ * reduce CPU load.
+ */
+
+static volatile adc_channel_values_t adc_dtc_block;
+static volatile adc_channel_values_t adc_dtc_block_cache;
+static const io_e *adc_pins;
+static uint8_t adc_pin_cnt;
+static uint8_t dtc_channel_cnt;
+
+static inline void adc_enable_and_start_conversion(void)
+{
+    ADC10CTL0 |= ENC + ADC10SC;
+}
+
+static bool initialized = false;
+void adc_init(void)
+{
+    ASSERT(!initialized);
+    adc_pins = io_adc_pins(&adc_pin_cnt);
+
+    uint8_t adc10ae0 = 0;
+    uint8_t last_idx = 0;
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t pin_idx = io_to_adc_idx(adc_pins[i]);
+        const uint8_t pin_bit = 1 << pin_idx;
+        adc10ae0 += pin_bit;
+        if (pin_idx > last_idx) {
+            last_idx = pin_idx;
+        }
+    }
+    const uint16_t inch = last_idx << 12;
+
+    /* inch: select channel
+     * ADC10DIV_&: Clock division (higher means slower)
+     * CONSEQ_1: Sequence of channels
+     * SHS_0: ADC10SC bit start conversion
+     * ADC10SSEL_1: ACLK as clock source (Slow)
+     */
+    ADC10CTL1 = inch + ADC10DIV_7 + CONSEQ_1 + SHS_0 + ADC10SSEL_1;
+    /* ADC10ON: Enable
+     * SREF_0: Voltage Ref (VCC and VSS)
+     * ADC10SHT_3: 64 * ADC10CLK sample and hold time (better readings?)
+     * MSC: Multiple sample consversion
+     * ADC10IE: Enable interrupt
+     */
+    ADC10CTL0 = ADC10ON + SREF_0 + ADC10SHT_3 + MSC + ADC10IE;
+
+    ADC10AE0 = adc10ae0;
+
+    /* Use data transfer controller (DTC) to transfer data DMA-style from
+     * the sampled channels and interrupt afterwards. Note, CONSEQ_1 iterates
+     * the channels contigously from last idx to 0
+     */
+    dtc_channel_cnt = last_idx + 1;
+    ADC10DTC0 = ADC10CT;
+    ADC10DTC1 = dtc_channel_cnt;
+    ADC10SA = (uint16_t)adc_dtc_block;
+
+    adc_enable_and_start_conversion();
+
+    initialized = true;
+}
+
+INTERRUPT_FUNCTION(ADC10_VECTOR) isr_adc10(void)
+{
+    for (uint8_t i = 0; i < dtc_channel_cnt; i++) {
+        // DTC writes the channel samples in opposite order
+        adc_dtc_block_cache[i] = adc_dtc_block[dtc_channel_cnt - 1 - i];
+    }
+    adc_enable_and_start_conversion();
+}
+
+void adc_get_channel_values(adc_channel_values_t values)
+{
+    // Not enough to only disable adc interrupts
+    _disable_interrupts();
+    for (uint8_t i = 0; i < adc_pin_cnt; i++) {
+        const uint8_t channel_idx = io_to_adc_idx(adc_pins[i]);
+        values[channel_idx] = adc_dtc_block_cache[channel_idx];
+    }
+    _enable_interrupts();
+}

--- a/src/drivers/adc.h
+++ b/src/drivers/adc.h
@@ -1,0 +1,14 @@
+#ifndef ADC_H
+#define ADC_H
+
+// ADC driver sampling the values of the ADC assignd 10 pins (see io.c)
+
+#include <stdint.h>
+
+#define ADC_CHANNEL_COUNT (8u)
+typedef uint16_t adc_channel_values_t[ADC_CHANNEL_COUNT];
+
+void adc_init(void);
+void adc_get_channel_values(adc_channel_values_t values);
+
+#endif // ADC_H

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -2,6 +2,7 @@
 #define IO_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* IO pin handling including pinmapping, initialization, and configuration.
  * This wraps the lower register defines provided in the headers from
@@ -33,7 +34,7 @@ typedef enum {
     IO_TEST_LED = IO_10,
     IO_UART_RX = IO_11,
     IO_UART_TX = IO_12,
-    IO_UNUSED_0 = IO_13,
+    IO_ADC_CHANNEL_0 = IO_13,
     IO_UNUSED_1 = IO_14,
     IO_UNUSED_2 = IO_15,
     IO_PWM_MOTORS_A = IO_16,
@@ -47,12 +48,12 @@ typedef enum {
     IO_UNUSED_11 = IO_26,
     IO_UNUSED_12 = IO_27,
 #elif defined(JR)
-    IO_ADC_CHANNEL_0 = IO_10,
+    IO_ADC_CHANNEL_0 = IO_10, // Front Left Line Sensor
     IO_UART_RX = IO_11,
     IO_UART_TX = IO_12,
-    IO_ADC_CHANNEL_3 = IO_13,
-    IO_ADC_CHANNEL_4 = IO_14,
-    IO_ADC_CHANNEL_5 = IO_15,
+    IO_ADC_CHANNEL_3 = IO_13, // Back Left Line Sensor
+    IO_ADC_CHANNEL_4 = IO_14, // Front Right Line Sensor
+    IO_ADC_CHANNEL_5 = IO_15, // Back Right Line Sensor
     IO_SCL = IO_16,
     IO_SDA = IO_17,
     IO_PWM_MOTORS_A = IO_20,
@@ -125,6 +126,8 @@ void io_set_direction(io_e io, io_dir_e direction);
 void io_set_resistor(io_e io, io_res_e resistor);
 void io_set_out(io_e io, io_out_e out);
 io_in_e io_get_input(io_e io);
+uint8_t io_to_adc_idx(io_e io);
+const io_e *io_adc_pins(uint8_t *cnt);
 
 typedef void (*isr_function)(void);
 void io_configure_interrupt(io_e io, io_trigger_e trigger, isr_function isr);

--- a/src/drivers/mcu_init.c
+++ b/src/drivers/mcu_init.c
@@ -15,6 +15,9 @@ static void init_clocks(void)
 
     // Sets the clock rate of the digitally controlled oscillator (DCO)
     DCOCTL = CALDCO_16MHZ;
+
+    // Select the internal Very Low Frequency Oscillator (VLO) as ACLK source
+    BCSCTL3 = LFXT1S_2;
 }
 
 /* Watchdog is set by default

--- a/src/drivers/qre1113.c
+++ b/src/drivers/qre1113.c
@@ -1,0 +1,25 @@
+#include "qre1113.h"
+#include "adc.h"
+#include "io.h"
+#include "../common/assert_handler.h"
+#include <stdbool.h>
+
+static bool initialized = false;
+void qre1113_init(void)
+{
+    ASSERT(!initialized);
+    adc_init();
+    initialized = true;
+}
+
+void qre1113_get_voltages(struct qre1113_voltages *voltages)
+{
+    adc_channel_values_t values;
+    adc_get_channel_values(values);
+    voltages->front_left = values[io_to_adc_idx(IO_ADC_CHANNEL_0)];
+#if defined(JR)
+    voltages->back_left = values[io_to_adc_idx(IO_ADC_CHANNEL_3)];
+    voltages->front_right = values[io_to_adc_idx(IO_ADC_CHANNEL_4)];
+    voltages->back_right = values[io_to_adc_idx(IO_ADC_CHANNEL_5)];
+#endif
+}

--- a/src/drivers/qre1113.h
+++ b/src/drivers/qre1113.h
@@ -1,0 +1,17 @@
+#ifndef QRE1113_H
+#define QRE1113_H
+
+#include <stdint.h>
+
+struct qre1113_voltages
+{
+    uint16_t front_left;
+    uint16_t front_right;
+    uint16_t back_left;
+    uint16_t back_right;
+};
+
+void qre1113_init(void);
+void qre1113_get_voltages(struct qre1113_voltages *voltages);
+
+#endif // QRE1113_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -6,6 +6,7 @@
 #include "../drivers/ir_remote.h"
 #include "../drivers/pwm.h"
 #include "../drivers/tb6612fng.h"
+#include "../drivers/adc.h"
 #include "../app/drive.h"
 #include "../common/assert_handler.h"
 #include "../common/defines.h"
@@ -307,6 +308,22 @@ static void test_assert_motors(void)
     BUSY_WAIT_ms(3000);
     ASSERT(0);
     while(0) {}
+}
+
+SUPPRESS_UNUSED
+static void test_adc(void)
+{
+    test_setup();
+    trace_init();
+    adc_init();
+    while(1) {
+        adc_channel_values_t values;
+        adc_get_channel_values(values);
+        for (uint8_t i = 0; i < ADC_CHANNEL_COUNT; i++){
+            TRACE("ADC ch %u: %u", i, values[i]);
+        }
+        BUSY_WAIT_ms(1000);
+    }
 }
 
 int main()

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -7,6 +7,7 @@
 #include "../drivers/pwm.h"
 #include "../drivers/tb6612fng.h"
 #include "../drivers/adc.h"
+#include "../drivers/qre1113.h"
 #include "../app/drive.h"
 #include "../common/assert_handler.h"
 #include "../common/defines.h"
@@ -323,6 +324,21 @@ static void test_adc(void)
             TRACE("ADC ch %u: %u", i, values[i]);
         }
         BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_qre1113(void)
+{
+    test_setup();
+    trace_init();
+    qre1113_init();
+    struct qre1113_voltages voltages = {0, 0, 0, 0};
+    while(1) {
+        qre1113_get_voltages(&voltages);
+        TRACE("Voltages fl: %u, fr: %u, bl: %u, br: %u", voltages.front_left, 
+                                            voltages.front_right, voltages.back_left, voltages.back_right);    
+    BUSY_WAIT_ms(1000);
     }
 }
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -9,6 +9,7 @@
 #include "../drivers/adc.h"
 #include "../drivers/qre1113.h"
 #include "../app/drive.h"
+#include "../app/line.h"
 #include "../common/assert_handler.h"
 #include "../common/defines.h"
 #include "../common/trace.h"
@@ -339,6 +340,18 @@ static void test_qre1113(void)
         TRACE("Voltages fl: %u, fr: %u, bl: %u, br: %u", voltages.front_left, 
                                             voltages.front_right, voltages.back_left, voltages.back_right);    
     BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_line(void)
+{
+    test_setup();
+    trace_init();
+    line_init();
+    while(1) {
+        TRACE("line %u", line_get());
+        BUSY_WAIT_ms(1000);
     }
 }
 


### PR DESCRIPTION
The robot will need 4 line sensors to determine if in the middle of the arena or on the edge. The line sensors will give an output voltage based on the light intensity they sense. Create an ADC driver to sample these voltages. Configure ADC10 peripheral to sample the channel contiguously. After all channels have been sampled, interrupt the MCU and cache the samples, then start again. Reduce CPU load by using DMA and a slower clock (ACLK).