### PR TITLE
feat(driver): i2c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,14 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/adc.c 	\
 	src/drivers/qre1113.c	\
 	src/drivers/i2c.c	\
+	src/drivers/vl53l0x.c \
 	src/app/drive.c	\
 	src/app/line.c	\
 	src/common/assert_handler.c \
 	src/common/ring_buffer.c \
 	src/common/trace.c 	\
 	external/printf/printf.c 
-#	src/drivers/i2c.c	\
-	src/app/enemy.c		\
+#	src/app/enemy.c		\
 
 ifndef TEST
 SOURCES = src/main.c \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/tb6612fng.c \
 	src/drivers/adc.c 	\
 	src/drivers/qre1113.c	\
+	src/drivers/i2c.c	\
 	src/app/drive.c	\
 	src/app/line.c	\
 	src/common/assert_handler.c \

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,12 @@ SOURCES_W_HEADERS = 	\
 	src/drivers/vl53l0x.c \
 	src/app/drive.c	\
 	src/app/line.c	\
+	src/app/enemy.c		\
 	src/common/assert_handler.c \
 	src/common/ring_buffer.c \
 	src/common/trace.c 	\
 	external/printf/printf.c 
-#	src/app/enemy.c		\
+
 
 ifndef TEST
 SOURCES = src/main.c \

--- a/src/app/enemy.c
+++ b/src/app/enemy.c
@@ -1,6 +1,143 @@
 #include "enemy.h"
+#include "../drivers/vl53l0x.h"
+#include "../common/assert_handler.h"
+#include "../common/trace.h"
 
+#define RANGE_DETECT_THRESHOLD (600u) // mm
+#define INVALID_RANGE (UINT16_MAX)
+#define RANGE_CLOSE (100u) // mm
+#define RANGE_MID (200u) // mm
+#define RANGE_FAR (300u) // mm
+
+// Nice to have enum to str function, can be deleted for more flash space
+const char *enemy_pos_str(enemy_pos_e pos)
+{
+    switch (pos) {
+    case ENEMY_POS_NONE:
+        return "NONE";
+    case ENEMY_POS_LEFT:
+        return "LEFT";
+    case ENEMY_POS_MID:
+        return "MID";
+    case ENEMY_POS_RIGHT:
+        return "RIGHT";
+    case ENEMY_POS_MID_LEFT:
+        return "MID LEFT";
+    case ENEMY_POS_MID_RIGHT:
+        return "MID RIGHT";
+    case ENEMY_POS_ALL:
+        return "ALL POS";
+    case ENEMY_POS_IMPOSSIBLE:
+        return "IMPOSSIBLE POS";
+    }
+    return "";
+}
+
+const char *enemy_range_str(enemy_range_e range)
+{
+    switch (range) {
+    case ENEMY_RANGE_NONE:
+        return "NONE";
+    case ENEMY_RANGE_CLOSE:
+        return "CLOSE";
+    case ENEMY_RANGE_MID:
+        return "MED";
+    case ENEMY_RANGE_FAR:
+        return "FAR";
+    }
+    return "";
+}
+struct enemy enemy_get(void)
+{
+    struct enemy enemy = { ENEMY_POS_NONE, ENEMY_RANGE_NONE };
+    vl53l0x_ranges_t ranges;
+    bool fresh_values = false;
+    vl53l0x_result_e result = vl53l0x_read_range_multiple(ranges, &fresh_values);
+    if (result) {
+        TRACE("Read range failed %u", result);
+        return enemy;
+    }
+    const uint16_t range_mid = ranges[VL53L0X_IDX_MID];
+    const uint16_t range_left = ranges[VL53L0X_IDX_LEFT];
+    const uint16_t range_right = ranges[VL53L0X_IDX_RIGHT];
+
+    const bool mid = range_mid < RANGE_DETECT_THRESHOLD;
+    const bool left = range_left < RANGE_DETECT_THRESHOLD;
+    const bool right = range_right < RANGE_DETECT_THRESHOLD;
+
+    uint16_t range = INVALID_RANGE;
+    if (mid) {
+        if (right && left) {
+            enemy.position = ENEMY_POS_ALL;
+            range = (((range_mid + range_left) / 2) + range_right) / 2;
+        } else if (right) {
+            enemy.position = ENEMY_POS_MID_RIGHT;
+            range = (range_mid + range_right) / 2;
+        } else if (left) {
+            enemy.position = ENEMY_POS_MID_LEFT;
+            range = (range_mid + range_left) / 2;
+        } else {
+            enemy.position = ENEMY_POS_MID;
+            range = range_mid;
+        }
+    } else if (right) {
+        if (left) {
+            enemy.position = ENEMY_POS_IMPOSSIBLE;
+        } else {
+            enemy.position = ENEMY_POS_RIGHT;
+            range = range_right;
+        }
+    } else if (left) {
+        enemy.position = ENEMY_POS_LEFT;
+        range = range_left;
+    } else {
+        enemy.position = ENEMY_POS_NONE;
+    }
+
+    if (range == INVALID_RANGE) {
+        return enemy;
+    }
+
+    if (range < RANGE_CLOSE) {
+        enemy.range = ENEMY_RANGE_CLOSE;
+    } else if (range < RANGE_MID) {
+        enemy.range = ENEMY_RANGE_MID;
+    } else {
+        enemy.range = ENEMY_RANGE_FAR;
+    }
+
+    return enemy;
+}
+
+bool enemy_detected(const struct enemy *enemy)
+{
+    return enemy->position != ENEMY_POS_NONE && enemy->position != ENEMY_POS_IMPOSSIBLE;
+}
+
+bool enemy_at_left(const struct enemy *enemy)
+{
+    return enemy->position == ENEMY_POS_LEFT || enemy->position == ENEMY_POS_MID_LEFT;
+}
+
+bool enemy_at_mid(const struct enemy *enemy)
+{
+    return enemy->position == ENEMY_POS_MID || enemy->position == ENEMY_POS_ALL;
+}
+
+bool enemy_at_right(const struct enemy *enemy)
+{
+    return enemy->position == ENEMY_POS_RIGHT || enemy->position == ENEMY_POS_MID_RIGHT;
+}
+
+static bool initialized = false;
 void enemy_init(void)
 {
-    // TODO: implement
+    ASSERT(!initialized);
+    vl53l0x_result_e result = vl53l0x_init();
+    if (result) {
+        TRACE("Failed to initialize vl53l0x %u", result);
+        return;
+    }
+
+    initialized = true;
 }

--- a/src/app/enemy.h
+++ b/src/app/enemy.h
@@ -1,6 +1,44 @@
 #ifndef ENEMY_H
 #define ENEMY_H
 
-void enemy_init(void);
+#include <stdbool.h>
 
-#endif
+/* A software layer that converts the range measurements into discrete
+ * enemy positions and distance to simplfy the application code
+ */
+
+typedef enum {
+    ENEMY_POS_NONE,
+    ENEMY_POS_LEFT,
+    ENEMY_POS_MID,
+    ENEMY_POS_RIGHT,
+    ENEMY_POS_MID_LEFT,
+    ENEMY_POS_MID_RIGHT,
+    ENEMY_POS_ALL,
+    ENEMY_POS_IMPOSSIBLE, // Keep for debugging purposes
+} enemy_pos_e;
+
+typedef enum {
+    ENEMY_RANGE_NONE,
+    ENEMY_RANGE_CLOSE,
+    ENEMY_RANGE_MID,
+    ENEMY_RANGE_FAR,
+} enemy_range_e;
+
+struct enemy
+{
+    enemy_pos_e position;
+    enemy_range_e range;
+};
+
+void enemy_init(void);
+struct enemy enemy_get(void);
+bool enemy_detected(const struct enemy *enemy);
+bool enemy_at_left(const struct enemy *enemy);
+bool enemy_at_right(const struct enemy *enemy);
+bool enemy_at_mid(const struct enemy *enemy);
+
+const char *enemy_pos_str(enemy_pos_e pos);
+const char *enemy_range_str(enemy_range_e range);
+
+#endif // ENEMY_H

--- a/src/common/assert_handler.c
+++ b/src/common/assert_handler.c
@@ -50,7 +50,7 @@ static void assert_blink_led(void)
 
 static void assert_stop_motors(void)
 {
-    GPIO_OUTPUT_LOW(1, 6); // Left PWM (Launchpad)
+    GPIO_OUTPUT_LOW(2, 6); // Left PWM (Launchpad)
     GPIO_OUTPUT_LOW(2, 1); // Right CC1 (JR)
     GPIO_OUTPUT_LOW(2, 2); // Right CC2 (JR)
     GPIO_OUTPUT_LOW(2, 4); // Left CC2 (JR & Launchpad)

--- a/src/drivers/i2c.c
+++ b/src/drivers/i2c.c
@@ -1,0 +1,233 @@
+#include "i2c.h"
+#include "io.h"
+#include "../common/assert_handler.h"
+#include "../common/defines.h"
+#include <msp430.h>
+#include <stdbool.h>
+
+#define DEFAULT_SLAVE_ADDRESS (0x29)
+#define RETRY_COUNT (UINT16_MAX)
+
+static inline void i2c_set_tx_byte(uint8_t byte)
+{
+    UCB0TXBUF = byte;
+}
+
+static i2c_result_e i2c_wait_tx_byte(void)
+{
+    uint16_t retries = RETRY_COUNT;
+    while (!(IFG2 & UCB0TXIFG) && retries--) { }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return (UCB0STAT & UCNACKIFG) ? I2C_RESULT_ERROR_TX : I2C_RESULT_OK;
+}
+
+static i2c_result_e i2c_wait_rx_byte(void)
+{
+    uint16_t retries = RETRY_COUNT;
+    while (!(IFG2 & UCB0RXIFG) && retries--) { }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return (UCB0STAT & UCNACKIFG) ? I2C_RESULT_ERROR_RX : I2C_RESULT_OK;
+}
+
+static inline uint8_t i2c_get_rx_byte(void)
+{
+    return UCB0RXBUF;
+}
+
+static inline void i2c_send_start_condition(void)
+{
+    // Send start condition (and slave address)
+    UCB0CTL1 |= UCTXSTT;
+}
+
+static i2c_result_e i2c_wait_start_condition(void)
+{
+    uint16_t retries = RETRY_COUNT;
+    while ((UCB0CTL1 & UCTXSTT) && --retries) { }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return (UCB0STAT & UCNACKIFG) ? I2C_RESULT_ERROR_START : I2C_RESULT_OK;
+}
+
+static i2c_result_e i2c_send_addr(const uint8_t *addr, uint8_t addr_size)
+{
+    // Configure as sender
+    UCB0CTL1 |= UCTR;
+    i2c_send_start_condition();
+
+    // Note, when master is TX, we must write to TXBUF before waiting for UCTXSTT
+    i2c_set_tx_byte(addr[0]);
+    i2c_result_e result = i2c_wait_start_condition();
+    if (result) {
+        return result;
+    }
+    result = i2c_wait_tx_byte();
+    if (result) {
+        return result;
+    }
+
+    // Send from most to least significant byte
+    for (uint8_t i = 1; i < addr_size; i++) {
+        i2c_set_tx_byte(addr[i]);
+        result = i2c_wait_tx_byte();
+        if (result) {
+            return result;
+        }
+    }
+
+    return result;
+}
+static i2c_result_e i2c_start_tx_transfer(const uint8_t *addr, uint8_t addr_size)
+{
+    return i2c_send_addr(addr, addr_size);
+}
+
+static i2c_result_e i2c_start_rx_transfer(const uint8_t *addr, uint8_t addr_size)
+{
+    i2c_result_e result = i2c_send_addr(addr, addr_size);
+    if (result) {
+        return result;
+    }
+
+    // Configure receiver
+    UCB0CTL1 &= ~UCTR;
+    i2c_send_start_condition();
+    result = i2c_wait_start_condition();
+    return result;
+}
+
+i2c_result_e i2c_stop_transfer(void)
+{
+    // Stop condition
+    UCB0CTL1 |= UCTXSTP;
+    uint16_t retries = RETRY_COUNT;
+    while ((UCB0CTL1 & UCTXSTP) && --retries) { }
+    if (retries == 0) {
+        return I2C_RESULT_ERROR_TIMEOUT;
+    }
+    return (UCB0STAT & UCNACKIFG) ? I2C_RESULT_ERROR_STOP : I2C_RESULT_OK;
+}
+
+i2c_result_e i2c_write(const uint8_t *addr, uint8_t addr_size, const uint8_t *data,
+                       uint8_t data_size)
+{
+    ASSERT(addr);
+    ASSERT(addr_size > 0);
+    ASSERT(data);
+    ASSERT(data_size > 0);
+
+    i2c_result_e result = i2c_start_tx_transfer(addr, addr_size);
+    if (result) {
+        return result;
+    }
+
+    // Send from most to least significant byte
+    for (uint16_t i = 0; i < data_size; i++) {
+        i2c_set_tx_byte(data[i]);
+        result = i2c_wait_tx_byte();
+        if (result) {
+            return result;
+        }
+    }
+
+    result = i2c_stop_transfer();
+
+    return result;
+}
+
+i2c_result_e i2c_read(const uint8_t *addr, uint8_t addr_size, uint8_t *data, uint8_t data_size)
+{
+    ASSERT(addr);
+    ASSERT(addr_size > 0);
+    ASSERT(data);
+    ASSERT(data_size > 0);
+
+    i2c_result_e result = i2c_start_rx_transfer(addr, addr_size);
+    if (result) {
+        return result;
+    }
+
+    // Read bytes from most to least significant byte
+    for (uint16_t i = data_size - 1; 1 <= i; i--) {
+        result = i2c_wait_rx_byte();
+        if (result) {
+            return result;
+        }
+        data[i] = i2c_get_rx_byte();
+    }
+
+    // Must stop before last byte
+    result = i2c_stop_transfer();
+    if (result) {
+        return result;
+    }
+    result = i2c_wait_rx_byte();
+    if (result) {
+        return result;
+    }
+    data[0] = i2c_get_rx_byte();
+
+    return I2C_RESULT_OK;
+}
+
+i2c_result_e i2c_read_addr8_data8(uint8_t addr, uint8_t *data)
+{
+    return i2c_read(&addr, 1, data, 1);
+}
+
+i2c_result_e i2c_read_addr8_data16(uint8_t addr, uint16_t *data)
+{
+    return i2c_read(&addr, 1, (uint8_t *)data, 2);
+}
+
+i2c_result_e i2c_read_addr8_data32(uint8_t addr, uint32_t *data)
+{
+    return i2c_read(&addr, 1, (uint8_t *)data, 4);
+}
+
+i2c_result_e i2c_write_addr8_data8(uint8_t addr, uint8_t data)
+{
+    return i2c_write(&addr, 1, &data, 1);
+}
+
+void i2c_set_slave_address(uint8_t addr)
+{
+    UCB0I2CSA = addr;
+}
+
+static bool initialized = false;
+void i2c_init(void)
+{
+    ASSERT(!initialized);
+
+    // Verify the pins are configured correctly
+    static const struct io_config i2c_config = {
+        .select = IO_SEL_ALT3, .resistor = IO_RES_DIS, .dir = IO_DIR_OUTPUT, .out = IO_OUT_LOW
+    };
+    struct io_config current_config;
+    io_get_current_config(IO_I2C_SCL, &current_config);
+    ASSERT(io_config_compare(&i2c_config, &current_config));
+    io_get_current_config(IO_I2C_SDA, &current_config);
+    ASSERT(io_config_compare(&i2c_config, &current_config));
+
+    /* Register Writes */
+    // Set reset while configuring
+    UCB0CTL1 |= UCSWRST;
+    // Single master, synchronous mode, I2C_mode
+    UCB0CTL0 = UCMST + UCSYNC + UCMODE_3;
+    // Set to SMCLK
+    UCB0CTL1 |= UCSSEL_2;
+    // SMCLK/160 ~= 100 KHz
+    UCB0BR0 = 160;
+    UCB0BR1 = 0;
+    // Clear Reset
+    UCB0CTL1 &= ~UCSWRST;
+    i2c_set_slave_address(DEFAULT_SLAVE_ADDRESS);
+
+    initialized = true;
+}

--- a/src/drivers/i2c.h
+++ b/src/drivers/i2c.h
@@ -1,0 +1,31 @@
+#ifndef I2C_H
+#define I2C_H
+
+#include <stdint.h>
+
+// Polling-based I2C master driver
+
+typedef enum {
+    I2C_RESULT_OK,
+    I2C_RESULT_ERROR_START,
+    I2C_RESULT_ERROR_TX,
+    I2C_RESULT_ERROR_RX,
+    I2C_RESULT_ERROR_STOP,
+    I2C_RESULT_ERROR_TIMEOUT,
+} i2c_result_e;
+
+void i2c_init(void);
+void i2c_set_slave_address(uint8_t addr);
+
+// These functions will send data in order from most to least significant byte
+i2c_result_e i2c_write(const uint8_t *addr, uint8_t addr_size, const uint8_t *data,
+                       uint8_t data_size);
+i2c_result_e i2c_read(const uint8_t *addr, uint8_t addr_size, uint8_t *data, uint8_t data_size);
+
+// Convenient wrapper functions
+i2c_result_e i2c_read_addr8_data8(uint8_t addr, uint8_t *data);
+i2c_result_e i2c_read_addr8_data16(uint8_t addr, uint16_t *data);
+i2c_result_e i2c_read_addr8_data32(uint8_t addr, uint32_t *data);
+i2c_result_e i2c_write_addr8_data8(uint8_t addr, uint8_t data);
+
+#endif // I2C_H

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -120,12 +120,17 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     // Output: Range Sesnor Outputs
     [IO_XSHUT_MID] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
 
+    /* Input: Range Sensor Inputs
+     * Range sensor provides open-drain output and should be
+     * connected to a pull up resistor, provided on the breakout board already.
+     */
+    [IO_RANGE_SENSOR_MID_INT] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_INPUT, IO_OUT_LOW },
+
 // Unused pins
 #if defined(LAUNCHPAD)
     [IO_UNUSED_1] = UNUSED_CONFIG,
     [IO_UNUSED_2] = UNUSED_CONFIG,
     [IO_UNUSED_6] = UNUSED_CONFIG,
-    [IO_UNUSED_7] = UNUSED_CONFIG,
     [IO_UNUSED_12] = UNUSED_CONFIG,
 #elif defined(JR)
 
@@ -135,13 +140,6 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
 
     // Output: PWM driven by Timer A1
     [IO_PWM_MOTORS_B] = { IO_SEL_ALT1, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
-
-    /* Input: Range Sensor Inputs
-     * Range sensor provides open-drain output and should be
-     * connected to an external pull up resistor, can also use internal
-     * pull-up resistor
-     */
-    [IO_INT_MID] = { IO_SEL_GPIO, IO_RES_EN, IO_DIR_OUTPUT, IO_OUT_HIGH },
 
     // Output: Range Sesnor Outputs
     [IO_XSHUT_RIGHT] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },

--- a/src/drivers/io.c
+++ b/src/drivers/io.c
@@ -109,24 +109,25 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
     // Input: Front left line sensor
     [IO_ADC_CHANNEL_0] = ADC_CONFIG,
 
-// Unused pins
-#if defined(LAUNCHPAD)
-    [IO_UNUSED_1] = UNUSED_CONFIG,
-    [IO_UNUSED_2] = UNUSED_CONFIG,
-    [IO_UNUSED_4] = UNUSED_CONFIG,
-    [IO_UNUSED_6] = UNUSED_CONFIG,
-    [IO_UNUSED_7] = UNUSED_CONFIG,
-    [IO_UNUSED_8] = UNUSED_CONFIG,
-    [IO_UNUSED_11] = UNUSED_CONFIG,
-    [IO_UNUSED_12] = UNUSED_CONFIG,
-#elif defined(JR)
     /* 12C clock/data: Range Sensor Data
      * Resistor: Not applicable
      * Direction: Not applicable
      * Output: Not applicable
      */
-    [IO_SCL] = { IO_SEL_ALT3, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
-    [IO_SDA] = { IO_SEL_ALT3, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
+    [IO_I2C_SCL] = { IO_SEL_ALT3, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
+    [IO_I2C_SDA] = { IO_SEL_ALT3, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
+
+    // Output: Range Sesnor Outputs
+    [IO_XSHUT_MID] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
+
+// Unused pins
+#if defined(LAUNCHPAD)
+    [IO_UNUSED_1] = UNUSED_CONFIG,
+    [IO_UNUSED_2] = UNUSED_CONFIG,
+    [IO_UNUSED_6] = UNUSED_CONFIG,
+    [IO_UNUSED_7] = UNUSED_CONFIG,
+    [IO_UNUSED_12] = UNUSED_CONFIG,
+#elif defined(JR)
 
     // Output: Motor Control Pins
     [IO_MOTORS_BIN_1] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
@@ -144,7 +145,6 @@ static const struct io_config io_initial_configs[IO_PORT_CNT * IO_PIN_CNT_PER_PO
 
     // Output: Range Sesnor Outputs
     [IO_XSHUT_RIGHT] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
-    [IO_XSHUT_MID] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
     [IO_XSHUT_LEFT] = { IO_SEL_GPIO, IO_RES_DIS, IO_DIR_OUTPUT, IO_OUT_LOW },
 
     // Output: Line Sensors

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -41,7 +41,7 @@ typedef enum {
     IO_I2C_SDA = IO_17,
     IO_IR_REMOTE = IO_20,
     IO_UNUSED_6 = IO_21,
-    IO_UNUSED_7 = IO_22,
+    IO_RANGE_SENSOR_MID_INT = IO_22,
     IO_XSHUT_MID = IO_23,
     IO_MOTORS_AIN_2 = IO_24,
     IO_MOTORS_AIN_1 = IO_25,
@@ -69,7 +69,7 @@ typedef enum {
     IO_XSHUT_RIGHT = IO_32,
     IO_XSHUT_MID = IO_33,
     IO_IR_REMOTE = IO_34,
-    IO_INT_MID = IO_35,
+    IO_RANGE_SENSOR_MID_INT = IO_35,
     IO_UNUSED_3 = IO_36,
     IO_UNUSED_4 = IO_37
 #endif

--- a/src/drivers/io.h
+++ b/src/drivers/io.h
@@ -37,15 +37,15 @@ typedef enum {
     IO_ADC_CHANNEL_0 = IO_13,
     IO_UNUSED_1 = IO_14,
     IO_UNUSED_2 = IO_15,
-    IO_PWM_MOTORS_A = IO_16,
-    IO_UNUSED_4 = IO_17,
+    IO_I2C_SCL = IO_16,
+    IO_I2C_SDA = IO_17,
     IO_IR_REMOTE = IO_20,
     IO_UNUSED_6 = IO_21,
     IO_UNUSED_7 = IO_22,
-    IO_UNUSED_8 = IO_23,
+    IO_XSHUT_MID = IO_23,
     IO_MOTORS_AIN_2 = IO_24,
     IO_MOTORS_AIN_1 = IO_25,
-    IO_UNUSED_11 = IO_26,
+    IO_PWM_MOTORS_A = IO_26,
     IO_UNUSED_12 = IO_27,
 #elif defined(JR)
     IO_ADC_CHANNEL_0 = IO_10, // Front Left Line Sensor
@@ -54,8 +54,8 @@ typedef enum {
     IO_ADC_CHANNEL_3 = IO_13, // Back Left Line Sensor
     IO_ADC_CHANNEL_4 = IO_14, // Front Right Line Sensor
     IO_ADC_CHANNEL_5 = IO_15, // Back Right Line Sensor
-    IO_SCL = IO_16,
-    IO_SDA = IO_17,
+    IO_I2C_SCL = IO_16,
+    IO_I2C_SDA = IO_17,
     IO_PWM_MOTORS_A = IO_20,
     IO_PWM_MOTORS_B = IO_21,
     IO_MOTORS_BIN_2 = IO_22,

--- a/src/drivers/ir_remote.c
+++ b/src/drivers/ir_remote.c
@@ -135,7 +135,7 @@ ir_cmd_e ir_remote_get_cmd(void)
 
 void ir_remote_init(void)
 {
-    io_configure_interrupt(IO_IR_REMOTE, IO_TRIGGER_FALLING, isr_pulse);
+    io_configure_interrupt(IO_IR_REMOTE, IO_TRIGGER_RISING, isr_pulse);
     io_enable_interrupt(IO_IR_REMOTE);
     timer_init();
 }

--- a/src/drivers/uart.c
+++ b/src/drivers/uart.c
@@ -143,11 +143,11 @@ void uart_init_assert(void)
 
 static void uart_putchar_polling(char c)
 {
-    while (!(IFG2 & UCA0TXIFG)) { }
-    UCA0TXBUF = c;
     if (c == '\n') {
         uart_putchar_polling('\r');
     }
+    UCA0TXBUF = c;
+    while (!(IFG2 & UCA0TXIFG)) { }
 }
 
 void uart_trace_assert(const char *string)

--- a/src/drivers/vl53l0x.c
+++ b/src/drivers/vl53l0x.c
@@ -1,0 +1,803 @@
+#include "vl53l0x.h"
+#include "i2c.h"
+#include "io.h"
+#include "../common/defines.h"
+#include "../common/assert_handler.h"
+
+#define REG_IDENTIFICATION_MODEL_ID (0xC0)
+#define REG_VHV_CONFIG_PAD_SCL_SDA_EXTSUP_HV (0x89)
+#define REG_MSRC_CONFIG_CONTROL (0x60)
+#define REG_FINAL_RANGE_CONFIG_MIN_COUNT_RATE_RTN_LIMIT (0x44)
+#define REG_SYSTEM_SEQUENCE_CONFIG (0x01)
+#define REG_DYNAMIC_SPAD_REF_EN_START_OFFSET (0x4F)
+#define REG_DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD (0x4E)
+#define REG_GLOBAL_CONFIG_REF_EN_START_SELECT (0xB6)
+#define REG_SYSTEM_INTERRUPT_CONFIG_GPIO (0x0A)
+#define REG_GPIO_HV_MUX_ACTIVE_HIGH (0x84)
+#define REG_SYSTEM_INTERRUPT_CLEAR (0x0B)
+#define REG_RESULT_INTERRUPT_STATUS (0x13)
+#define REG_SYSRANGE_START (0x00)
+#define REG_GLOBAL_CONFIG_SPAD_ENABLES_REF_0 (0xB0)
+#define REG_RESULT_RANGE_STATUS (0x14)
+#define REG_SLAVE_DEVICE_ADDRESS (0x8A)
+
+#define RANGE_SEQUENCE_STEP_TCC (0x10) // Target CentreCheck
+#define RANGE_SEQUENCE_STEP_MSRC (0x04) // Minimum Signal Rate Check
+#define RANGE_SEQUENCE_STEP_DSS (0x28) // Dynamic SPAD selection
+#define RANGE_SEQUENCE_STEP_PRE_RANGE (0x40)
+#define RANGE_SEQUENCE_STEP_FINAL_RANGE (0x80)
+
+#define VL53L0X_EXPECTED_DEVICE_ID (0xEE)
+#define VL53L0X_DEFAULT_ADDRESS (0x29)
+
+/* There are two types of SPAD: aperture and non-aperture. My understanding
+ * is that aperture ones let it less light (they have a smaller opening), similar
+ * to how you can change the aperture on a digital camera. Only 1/4 th of the
+ * SPADs are of type non-aperture. */
+#define SPAD_TYPE_APERTURE (0x01)
+/* The total SPAD array is 16x16, but we can only activate a quadrant spanning 44 SPADs at
+ * a time. In the ST api code they have (for some reason) selected 0xB4 (180) as a starting
+ * point (lies in the middle and spans non-aperture (3rd) quadrant and aperture (4th) quadrant). */
+#define SPAD_START_SELECT (0xB4)
+/* The total SPAD map is 16x16, but we should only activate an area of 44 SPADs at a time. */
+#define SPAD_MAX_COUNT (44)
+/* The 44 SPADs are represented as 6 bytes where each bit represents a single SPAD.
+ * 6x8 = 48, so the last four bits are unused. */
+#define SPAD_MAP_ROW_COUNT (6)
+#define SPAD_ROW_SIZE (8)
+/* Since we start at 0xB4 (180), there are four quadrants (three aperture, one aperture),
+ * and each quadrant contains 256 / 4 = 64 SPADs, and the third quadrant is non-aperture, the
+ * offset to the aperture quadrant is (256 - 64 - 180) = 12 */
+#define SPAD_APERTURE_START_INDEX (12)
+
+typedef enum {
+    VL53L0X_CALIBRATION_TYPE_VHV,
+    VL53L0X_CALIBRATION_TYPE_PHASE
+} vl53l0x_calibration_type_e;
+
+typedef enum {
+    STATUS_MULTIPLE_NOT_STARTED,
+    STATUS_MULTIPLE_MEASURING,
+    STATUS_MULTIPLE_DONE
+} status_multiple_e;
+
+struct vl53l0x_cfg
+{
+    uint8_t addr;
+    io_e xshut_io;
+};
+
+struct i2c_8reg
+{
+    uint8_t addr;
+    uint8_t data;
+};
+
+static const struct vl53l0x_cfg vl53l0x_cfgs[] = {
+    [VL53L0X_IDX_MID] = { .addr = 0x30, .xshut_io = IO_XSHUT_MID },
+#if defined(JR)
+    [VL53L0X_IDX_LEFT] = { .addr = 0x31, .xshut_io = IO_XSHUT_LEFT },
+    [VL53L0X_IDX_RIGHT] = { .addr = 0x32, .xshut_io = IO_XSHUT_RIGHT },
+#endif
+};
+
+static uint8_t stop_variable = 0;
+// Reads/Writes to this can be considered atomic on MSP430
+static volatile status_multiple_e status_multiple = STATUS_MULTIPLE_NOT_STARTED;
+static bool initialized = false;
+
+/* We can read the model id to confirm that the device is booted.
+ * (There is no fresh_out_of_reset as on the vl6180x) */
+static vl53l0x_result_e device_is_booted(void)
+{
+    uint8_t device_id = 0;
+    if (i2c_read_addr8_data8(REG_IDENTIFICATION_MODEL_ID, &device_id)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return (device_id == VL53L0X_EXPECTED_DEVICE_ID) ? VL53L0X_RESULT_OK
+                                                     : VL53L0X_RESULT_ERROR_BOOT;
+}
+
+static vl53l0x_result_e vl53l0x_write_8regs(const struct i2c_8reg *regs, uint8_t cnt)
+{
+    for (uint8_t i = 0; i < cnt; i++) {
+        if (i2c_write_addr8_data8(regs[i].addr, regs[i].data)) {
+            return VL53L0X_RESULT_ERROR_I2C;
+        }
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+// One time device initialization
+static vl53l0x_result_e vl53l0x_data_init(void)
+{
+    // Set 2v8 mode
+    uint8_t vhv_config_scl_sda = 0;
+    if (i2c_read_addr8_data8(REG_VHV_CONFIG_PAD_SCL_SDA_EXTSUP_HV, &vhv_config_scl_sda)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    vhv_config_scl_sda |= 0x01;
+    if (i2c_write_addr8_data8(REG_VHV_CONFIG_PAD_SCL_SDA_EXTSUP_HV, vhv_config_scl_sda)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    // Set I2C standard mode
+    if (i2c_write_addr8_data8(0x88, 0x00)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    // Set various registers (same as ST reference code)
+    const struct i2c_8reg data_regs1[] = { { 0x80, 0x01 }, { 0xFF, 0x01 }, { 0x00, 0x00 } };
+    vl53l0x_result_e result = vl53l0x_write_8regs(data_regs1, ARRAY_SIZE(data_regs1));
+    if (result) {
+        return result;
+    }
+
+    // TODO: It may be unnecessary to retrieve the stop variable for each sensor
+    if (i2c_read_addr8_data8(0x91, &stop_variable)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    // Set various registers (same as ST reference code)
+    const struct i2c_8reg data_regs2[] = { { 0x00, 0x01 }, { 0xFF, 0x00 }, { 0x80, 0x00 } };
+    result = vl53l0x_write_8regs(data_regs2, ARRAY_SIZE(data_regs2));
+
+    return result;
+}
+
+/* Wait for strobe value to be set. This is used when we read values
+ * from NVM (non volatile memory). */
+static vl53l0x_result_e vl53l0x_read_strobe(void)
+{
+    uint8_t strobe = 0;
+    if (i2c_write_addr8_data8(0x83, 0x00)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    i2c_result_e result = I2C_RESULT_OK;
+    do {
+        result = i2c_read_addr8_data8(0x83, &strobe);
+    } while (result == I2C_RESULT_OK && (strobe == 0));
+    if (result) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    if (i2c_write_addr8_data8(0x83, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+/**
+ * Gets the spad count, spad type och "good" spad map stored by ST in NVM at
+ * their production line.
+ * .
+ * According to the datasheet, ST runs a calibration (without cover glass) and
+ * saves a "good" SPAD map to NVM (non volatile memory). The SPAD array has two
+ * types of SPADs: aperture and non-aperture. By default, all of the
+ * good SPADs are enabled, but we should only enable a subset of them to get
+ * an optimized signal rate. We should also only enable either only aperture
+ * or only non-aperture SPADs. The number of SPADs to enable and which type
+ * are also saved during the calibration step at ST factory and can be retrieved
+ * from NVM.
+ */
+static vl53l0x_result_e vl53l0x_get_spad_info_from_nvm(uint8_t *spad_count, uint8_t *spad_type,
+                                                       uint8_t good_spad_map[6])
+{
+    uint8_t tmp_data8 = 0;
+    uint32_t tmp_data32 = 0;
+
+    const struct i2c_8reg nvm_setup_regs[] = { { 0x80, 0x01 }, { 0xFF, 0x01 }, { 0x00, 0x00 },
+                                               { 0xFF, 0x06 }, { 0xFF, 0x07 }, { 0x81, 0x01 },
+                                               { 0x80, 0x01 } };
+
+    // Setup to read from NVM
+    vl53l0x_result_e result = vl53l0x_write_8regs(nvm_setup_regs, 4);
+    if (result) {
+        return result;
+    }
+    if (i2c_read_addr8_data8(0x83, &tmp_data8)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    if (i2c_write_addr8_data8(0x83, tmp_data8 | 0x04)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    result = vl53l0x_write_8regs(nvm_setup_regs + 4, ARRAY_SIZE(nvm_setup_regs) - 4);
+    if (result) {
+        return result;
+    }
+
+    // Get the SPAD count and type
+    if (i2c_write_addr8_data8(0x94, 0x6b)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    result = vl53l0x_read_strobe();
+    if (result) {
+        return result;
+    }
+    if (i2c_read_addr8_data32(0x90, &tmp_data32)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    *spad_count = (tmp_data32 >> 8) & 0x7f;
+    *spad_type = (tmp_data32 >> 15) & 0x01;
+
+    const struct i2c_8reg nvm_restore_regs[] = { { 0x81, 0x00 }, { 0xFF, 0x06 }, { 0xFF, 0x01 },
+                                                 { 0x00, 0x01 }, { 0xFF, 0x00 }, { 0x80, 0x00 } };
+
+    // Restore after reading from NVM
+    result = vl53l0x_write_8regs(nvm_restore_regs, 2);
+    if (result) {
+        return result;
+    }
+    if (i2c_read_addr8_data8(0x83, &tmp_data8)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    if (i2c_write_addr8_data8(0x83, tmp_data8 & 0xfb)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    result = vl53l0x_write_8regs(nvm_restore_regs + 2, ARRAY_SIZE(nvm_restore_regs) - 2);
+    if (result) {
+        return result;
+    }
+
+    /* When we haven't configured the SPAD map yet, the SPAD map register actually
+     * contains the good SPAD map, so we can retrieve it straight from this register
+     * instead of reading it from the NVM. */
+    const uint8_t reg_global_cfg_addr = REG_GLOBAL_CONFIG_SPAD_ENABLES_REF_0;
+    result = i2c_read(&reg_global_cfg_addr, 1, good_spad_map, 6);
+    return result;
+}
+
+/**
+ * Sets the SPADs according to the value saved to NVM by ST during production. Assuming
+ * similar conditions (e.g. no cover glass), this should give reasonable readings and we
+ * can avoid running ref spad management (tedious code).
+ */
+static vl53l0x_result_e vl53l0x_set_spads_from_nvm(void)
+{
+    uint8_t spad_map[SPAD_MAP_ROW_COUNT] = { 0 };
+    uint8_t good_spad_map[SPAD_MAP_ROW_COUNT] = { 0 };
+    uint8_t spads_enabled_count = 0;
+    uint8_t spads_to_enable_count = 0;
+    uint8_t spad_type = 0;
+
+    vl53l0x_result_e result =
+        vl53l0x_get_spad_info_from_nvm(&spads_to_enable_count, &spad_type, good_spad_map);
+    if (result) {
+        return result;
+    }
+
+    const struct i2c_8reg spad_regs[] = { { 0xFF, 0x01 },
+                                          { REG_DYNAMIC_SPAD_REF_EN_START_OFFSET, 0x00 },
+                                          { REG_DYNAMIC_SPAD_NUM_REQUESTED_REF_SPAD, 0x2C },
+                                          { 0xFF, 0x00 },
+                                          { REG_GLOBAL_CONFIG_REF_EN_START_SELECT,
+                                            SPAD_START_SELECT } };
+    result = vl53l0x_write_8regs(spad_regs, ARRAY_SIZE(spad_regs));
+    if (result) {
+        return result;
+    }
+
+    uint8_t offset = (spad_type == SPAD_TYPE_APERTURE) ? SPAD_APERTURE_START_INDEX : 0;
+
+    /* Create a new SPAD array by selecting a subset of the SPADs suggested by the good SPAD map.
+     * The subset should only have the number of type enabled as suggested by the reading from
+     * the NVM (spads_to_enable_count and spad_type). */
+    for (int row = 0; row < SPAD_MAP_ROW_COUNT; row++) {
+        for (int column = 0; column < SPAD_ROW_SIZE; column++) {
+            int index = (row * SPAD_ROW_SIZE) + column;
+            if (index >= SPAD_MAX_COUNT) {
+                return VL53L0X_RESULT_ERROR_SPAD;
+            }
+            if (spads_enabled_count == spads_to_enable_count) {
+                // We are done
+                break;
+            }
+            if (index < offset) {
+                continue;
+            }
+            if ((good_spad_map[row] >> column) & 0x1) {
+                spad_map[row] |= (1 << column);
+                spads_enabled_count++;
+            }
+        }
+        if (spads_enabled_count == spads_to_enable_count) {
+            // To avoid looping unnecessarily when we are already done.
+            break;
+        }
+    }
+
+    if (spads_enabled_count != spads_to_enable_count) {
+        return VL53L0X_RESULT_ERROR_SPAD;
+    }
+
+    // Write the new SPAD configuration
+    const uint8_t reg_global_cfg_addr = REG_GLOBAL_CONFIG_SPAD_ENABLES_REF_0;
+    if (i2c_write(&reg_global_cfg_addr, 1, spad_map, SPAD_MAP_ROW_COUNT)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    return VL53L0X_RESULT_OK;
+}
+
+// Load tuning settings (same as default tuning settings provided by ST api code)
+static vl53l0x_result_e vl53l0x_load_default_tuning_settings(void)
+{
+    const struct i2c_8reg default_tuning_regs[] = {
+        { 0xFF, 0x01 }, { 0x00, 0x00 }, { 0xFF, 0x00 }, { 0x09, 0x00 }, { 0x10, 0x00 },
+        { 0x11, 0x00 }, { 0x24, 0x01 }, { 0x25, 0xFF }, { 0x75, 0x00 }, { 0xFF, 0x01 },
+        { 0x4E, 0x2C }, { 0x48, 0x00 }, { 0x30, 0x20 }, { 0xFF, 0x00 }, { 0x30, 0x09 },
+        { 0x54, 0x00 }, { 0x31, 0x04 }, { 0x32, 0x03 }, { 0x40, 0x83 }, { 0x46, 0x25 },
+        { 0x60, 0x00 }, { 0x27, 0x00 }, { 0x50, 0x06 }, { 0x51, 0x00 }, { 0x52, 0x96 },
+        { 0x56, 0x08 }, { 0x57, 0x30 }, { 0x61, 0x00 }, { 0x62, 0x00 }, { 0x64, 0x00 },
+        { 0x65, 0x00 }, { 0x66, 0xA0 }, { 0xFF, 0x01 }, { 0x22, 0x32 }, { 0x47, 0x14 },
+        { 0x49, 0xFF }, { 0x4A, 0x00 }, { 0xFF, 0x00 }, { 0x7A, 0x0A }, { 0x7B, 0x00 },
+        { 0x78, 0x21 }, { 0xFF, 0x01 }, { 0x23, 0x34 }, { 0x42, 0x00 }, { 0x44, 0xFF },
+        { 0x45, 0x26 }, { 0x46, 0x05 }, { 0x40, 0x40 }, { 0x0E, 0x06 }, { 0x20, 0x1A },
+        { 0x43, 0x40 }, { 0xFF, 0x00 }, { 0x34, 0x03 }, { 0x35, 0x44 }, { 0xFF, 0x01 },
+        { 0x31, 0x04 }, { 0x4B, 0x09 }, { 0x4C, 0x05 }, { 0x4D, 0x04 }, { 0xFF, 0x00 },
+        { 0x44, 0x00 }, { 0x45, 0x20 }, { 0x47, 0x08 }, { 0x48, 0x28 }, { 0x67, 0x00 },
+        { 0x70, 0x04 }, { 0x71, 0x01 }, { 0x72, 0xFE }, { 0x76, 0x00 }, { 0x77, 0x00 },
+        { 0xFF, 0x01 }, { 0x0D, 0x01 }, { 0xFF, 0x00 }, { 0x80, 0x01 }, { 0x01, 0xF8 },
+        { 0xFF, 0x01 }, { 0x8E, 0x01 }, { 0x00, 0x01 }, { 0xFF, 0x00 }, { 0x80, 0x00 }
+    };
+    return vl53l0x_write_8regs(default_tuning_regs, ARRAY_SIZE(default_tuning_regs));
+}
+
+static vl53l0x_result_e vl53l0x_configure_interrupt(void)
+{
+    // Interrupt on new sample ready
+    if (i2c_write_addr8_data8(REG_SYSTEM_INTERRUPT_CONFIG_GPIO, 0x04)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    /* Configure active low since the pin is pulled-up on most breakout boards */
+    uint8_t gpio_hv_mux_active_high = 0;
+    if (i2c_read_addr8_data8(REG_GPIO_HV_MUX_ACTIVE_HIGH, &gpio_hv_mux_active_high)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    gpio_hv_mux_active_high &= ~0x10;
+    if (i2c_write_addr8_data8(REG_GPIO_HV_MUX_ACTIVE_HIGH, gpio_hv_mux_active_high)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    if (i2c_write_addr8_data8(REG_SYSTEM_INTERRUPT_CLEAR, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+static void mid_measurement_done_isr()
+{
+    status_multiple = STATUS_MULTIPLE_DONE;
+}
+
+static void vl53l0x_configure_mid_sensor_interrupt(void)
+{
+    static const struct io_config mid_interrupt_config = {
+        .select = IO_SEL_GPIO,
+        .resistor = IO_RES_DIS,
+        .dir = IO_DIR_INPUT,
+        .out = IO_OUT_LOW,
+    };
+    struct io_config current_config;
+    io_get_current_config(IO_RANGE_SENSOR_MID_INT, &current_config);
+    ASSERT(io_config_compare(&mid_interrupt_config, &current_config));
+
+    io_configure_interrupt(IO_RANGE_SENSOR_MID_INT, IO_TRIGGER_FALLING, mid_measurement_done_isr);
+    io_enable_interrupt(IO_RANGE_SENSOR_MID_INT);
+}
+
+// Enable (or disable) specific steps in the sequence
+static vl53l0x_result_e vl53l0x_set_sequence_steps_enabled(uint8_t sequence_step)
+{
+    if (i2c_write_addr8_data8(REG_SYSTEM_SEQUENCE_CONFIG, sequence_step)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+// Basic device initialization
+static vl53l0x_result_e vl53l0x_static_init(void)
+{
+    vl53l0x_result_e result = vl53l0x_set_spads_from_nvm();
+    if (result) {
+        return result;
+    }
+
+    result = vl53l0x_load_default_tuning_settings();
+    if (result) {
+        return result;
+    }
+
+    result = vl53l0x_configure_interrupt();
+    if (result) {
+        return result;
+    }
+
+    result = vl53l0x_set_sequence_steps_enabled(
+        RANGE_SEQUENCE_STEP_DSS + RANGE_SEQUENCE_STEP_PRE_RANGE + RANGE_SEQUENCE_STEP_FINAL_RANGE);
+    return result;
+}
+
+static vl53l0x_result_e
+vl53l0x_perform_single_ref_calibration(vl53l0x_calibration_type_e calib_type)
+{
+    uint8_t sysrange_start = 0;
+    uint8_t sequence_config = 0;
+    switch (calib_type) {
+    case VL53L0X_CALIBRATION_TYPE_VHV:
+        sequence_config = 0x01;
+        sysrange_start = 0x01 | 0x40;
+        break;
+    case VL53L0X_CALIBRATION_TYPE_PHASE:
+        sequence_config = 0x02;
+        sysrange_start = 0x01;
+        break;
+    }
+    if (i2c_write_addr8_data8(REG_SYSTEM_SEQUENCE_CONFIG, sequence_config)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    if (i2c_write_addr8_data8(REG_SYSRANGE_START, sysrange_start)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    // Wait for interrupt
+    uint8_t interrupt_status = 0;
+    i2c_result_e i2c_result = I2C_RESULT_OK;
+    do {
+        i2c_result = i2c_read_addr8_data8(REG_RESULT_INTERRUPT_STATUS, &interrupt_status);
+    } while (i2c_result == I2C_RESULT_OK && ((interrupt_status & 0x07) == 0));
+    if (i2c_result) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    if (i2c_write_addr8_data8(REG_SYSTEM_INTERRUPT_CLEAR, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    if (i2c_write_addr8_data8(REG_SYSRANGE_START, 0x00)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+/* Temperature calibration needs to be run again if the temperature changes by
+ * more than 8 degrees according to the datasheet. */
+static vl53l0x_result_e vl53l0x_perform_ref_calibration(void)
+{
+    vl53l0x_result_e result = vl53l0x_perform_single_ref_calibration(VL53L0X_CALIBRATION_TYPE_VHV);
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_perform_single_ref_calibration(VL53L0X_CALIBRATION_TYPE_PHASE);
+    if (result) {
+        return result;
+    }
+    // Restore sequence steps enabled
+    result = vl53l0x_set_sequence_steps_enabled(
+        RANGE_SEQUENCE_STEP_DSS + RANGE_SEQUENCE_STEP_PRE_RANGE + RANGE_SEQUENCE_STEP_FINAL_RANGE);
+    return result;
+}
+
+static vl53l0x_result_e vl53l0x_configure_address(uint8_t addr)
+{
+    // 7-bit address
+    if (i2c_write_addr8_data8(REG_SLAVE_DEVICE_ADDRESS, addr & 0x7F)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+// Sets the sensor in hardware standby by flipping the XSHUT pin.
+static void vl53l0x_set_hardware_standby(vl53l0x_idx_e idx, bool enable)
+{
+    io_set_out(vl53l0x_cfgs[idx].xshut_io, enable ? IO_OUT_LOW : IO_OUT_HIGH);
+}
+
+/* Configures the GPIOs used for the XSHUT pin.
+ * Output low by default means the sensors will be in
+ * hardware standby after this function is called. */
+static void vl53l0x_assert_xshut_pins(void)
+{
+    static const struct io_config xshut_config = {
+        .select = IO_SEL_GPIO,
+        .resistor = IO_RES_DIS,
+        .dir = IO_DIR_OUTPUT,
+        .out = IO_OUT_LOW,
+    };
+    struct io_config current_config;
+    io_get_current_config(IO_XSHUT_MID, &current_config);
+    ASSERT(io_config_compare(&xshut_config, &current_config));
+#if defined(JR)
+    io_get_current_config(IO_XSHUT_LEFT, &current_config);
+    ASSERT(io_config_compare(&xshut_config, &current_config));
+    io_get_current_config(IO_XSHUT_RIGHT, &current_config);
+    ASSERT(io_config_compare(&xshut_config, &current_config));
+#endif
+}
+
+/* Sets the address of a single VL53L0X sensor.
+ * This functions assumes that all non-configured VL53L0X are still
+ * in hardware standby. */
+static vl53l0x_result_e vl53l0x_init_address(vl53l0x_idx_e idx)
+{
+    vl53l0x_set_hardware_standby(idx, false);
+    i2c_set_slave_address(VL53L0X_DEFAULT_ADDRESS);
+
+    /* The datasheet doesn't say how long we must wait to leave hw standby,
+     * but using the same delay as vl6180x seems to work fine. */
+    /* TODO: Tune this delay */
+    __delay_cycles(10000);
+
+    vl53l0x_result_e result = device_is_booted();
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_configure_address(vl53l0x_cfgs[idx].addr);
+    return result;
+}
+
+/* Initializes the sensors by putting them in hw standby and then
+ * waking them up one-by-one as described in AN4846. */
+static vl53l0x_result_e vl53l0x_init_addresses(void)
+{
+    // Default IO config should put all sensors in hardware standby
+    vl53l0x_assert_xshut_pins();
+
+    // Wake each sensor up one by one and set a unique address for each one
+    vl53l0x_result_e result = vl53l0x_init_address(VL53L0X_IDX_MID);
+    if (result) {
+        return result;
+    }
+#if defined(JR)
+    result = vl53l0x_init_address(VL53L0X_IDX_LEFT);
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_init_address(VL53L0X_IDX_RIGHT);
+    if (result) {
+        return result;
+    }
+#endif
+    return VL53L0X_RESULT_OK;
+}
+
+static vl53l0x_result_e vl53l0x_init_config(vl53l0x_idx_e idx)
+{
+    i2c_set_slave_address(vl53l0x_cfgs[idx].addr);
+    vl53l0x_result_e result = vl53l0x_data_init();
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_static_init();
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_perform_ref_calibration();
+    if (result) {
+        return result;
+    }
+
+    if (idx == VL53L0X_IDX_MID) {
+        vl53l0x_configure_mid_sensor_interrupt();
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+static vl53l0x_result_e vl53l0x_start_sysrange(vl53l0x_idx_e idx)
+{
+    i2c_set_slave_address(vl53l0x_cfgs[idx].addr);
+    const struct i2c_8reg sysrange_regs[] = { { 0x80, 0x01 }, { 0xFF, 0x01 }, { 0x00, 0x00 },
+                                              { 0x00, 0x01 }, { 0xFF, 0x00 }, { 0x80, 0x00 } };
+    vl53l0x_result_e result = vl53l0x_write_8regs(sysrange_regs, 3);
+    if (result) {
+        return result;
+    }
+    if (i2c_write_addr8_data8(0x91, stop_variable)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    result = vl53l0x_write_8regs(sysrange_regs + 3, ARRAY_SIZE(sysrange_regs) - 3);
+    if (result) {
+        return result;
+    }
+
+    if (i2c_write_addr8_data8(REG_SYSRANGE_START, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    uint8_t sysrange_start = 0;
+    i2c_result_e i2c_result = I2C_RESULT_OK;
+    do {
+        i2c_result = i2c_read_addr8_data8(REG_SYSRANGE_START, &sysrange_start);
+    } while (i2c_result == I2C_RESULT_OK && (sysrange_start & 0x01));
+    return i2c_result == I2C_RESULT_OK ? VL53L0X_RESULT_OK : VL53L0X_RESULT_ERROR_I2C;
+}
+
+// Assumes I2C address is set already
+static vl53l0x_result_e vl53l0x_clear_sysrange_interrupt(void)
+{
+    if (i2c_write_addr8_data8(REG_SYSTEM_INTERRUPT_CLEAR, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+    return VL53L0X_RESULT_OK;
+}
+
+// Assumes I2C address is set already
+static vl53l0x_result_e vl53l0x_pollwait_sysrange(void)
+{
+    i2c_result_e i2c_result = I2C_RESULT_OK;
+    uint8_t interrupt_status = 0;
+    do {
+        i2c_result = i2c_read_addr8_data8(REG_RESULT_INTERRUPT_STATUS, &interrupt_status);
+    } while (i2c_result == I2C_RESULT_OK && ((interrupt_status & 0x07) == 0));
+    return i2c_result == I2C_RESULT_OK ? VL53L0X_RESULT_OK : VL53L0X_RESULT_ERROR_I2C;
+}
+
+static bool vl53l0x_is_sysrange_done(vl53l0x_idx_e idx)
+{
+    i2c_set_slave_address(vl53l0x_cfgs[idx].addr);
+    uint8_t interrupt_status = 0;
+    const i2c_result_e i2c_result =
+        i2c_read_addr8_data8(REG_RESULT_INTERRUPT_STATUS, &interrupt_status);
+    return i2c_result == I2C_RESULT_OK && (interrupt_status & 0x07);
+}
+
+static vl53l0x_result_e vl53l0x_read_range(vl53l0x_idx_e idx, uint16_t *range)
+{
+    i2c_set_slave_address(vl53l0x_cfgs[idx].addr);
+
+    vl53l0x_result_e result = vl53l0x_pollwait_sysrange();
+    if (result) {
+        return result;
+    }
+
+    if (i2c_read_addr8_data16(REG_RESULT_RANGE_STATUS + 10, range)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    if (i2c_write_addr8_data8(REG_SYSTEM_INTERRUPT_CLEAR, 0x01)) {
+        return VL53L0X_RESULT_ERROR_I2C;
+    }
+
+    // 8190 or 8191 may be returned when obstacle is out of range.
+    if (*range == 8190 || *range == 8191) {
+        *range = VL53L0X_OUT_OF_RANGE;
+    }
+
+    result = vl53l0x_clear_sysrange_interrupt();
+    return result;
+}
+
+vl53l0x_result_e vl53l0x_read_range_single(vl53l0x_idx_e idx, uint16_t *range)
+{
+    ASSERT(initialized);
+    vl53l0x_result_e result = vl53l0x_start_sysrange(idx);
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_read_range(idx, range);
+    return result;
+}
+
+// TODO: Verify this works after bring up real robot
+vl53l0x_result_e vl53l0x_start_measuring_multiple(void)
+{
+    ASSERT(initialized);
+    if (status_multiple == STATUS_MULTIPLE_MEASURING) {
+        return VL53L0X_RESULT_ERROR_MEASURE_ONGOING;
+    }
+    status_multiple = STATUS_MULTIPLE_MEASURING;
+    vl53l0x_result_e result = vl53l0x_start_sysrange(VL53L0X_IDX_MID);
+    if (result) {
+        return result;
+    }
+#if defined(JR)
+    result = vl53l0x_start_sysrange(VL53L0X_IDX_LEFT);
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_start_sysrange(VL53L0X_IDX_RIGHT);
+    if (result) {
+        return result;
+    }
+#endif
+    return VL53L0X_RESULT_OK;
+}
+
+static vl53l0x_ranges_t latest_ranges = { VL53L0X_OUT_OF_RANGE, VL53L0X_OUT_OF_RANGE,
+                                          VL53L0X_OUT_OF_RANGE };
+
+/*
+ * The approach is as follow:
+ * For multiple sensors and single interrupt line:
+ * 1. Start measure on all sensors
+ * 2. If measurement ready
+ *    - Read measurement of all sensors
+ * 3. else
+ *    - Return old values
+ * 4. Update measurement ready on interrupt
+ */
+// TODO: Verify this works after bring up real robot
+vl53l0x_result_e vl53l0x_read_range_multiple(vl53l0x_ranges_t ranges, bool *fresh_values)
+{
+    ASSERT(initialized);
+    vl53l0x_result_e result = VL53L0X_RESULT_OK;
+    if (status_multiple == STATUS_MULTIPLE_NOT_STARTED) {
+        result = vl53l0x_start_measuring_multiple();
+        if (result) {
+            return result;
+        }
+        // Block here the first time
+        while (status_multiple != STATUS_MULTIPLE_DONE) { }
+    }
+
+    bool sensors_done = true;
+#if defined(JR)
+    // We already know mid is done because of its interrupt
+    //&& vl53l0x_is_sysrange_done(VL53L0X_IDX_MID)
+    sensors_done =
+        vl53l0x_is_sysrange_done(VL53L0X_IDX_LEFT) && vl53l0x_is_sysrange_done(VL53L0X_IDX_RIGHT);
+#endif
+
+    if (status_multiple == STATUS_MULTIPLE_DONE && sensors_done) {
+
+        if (!vl53l0x_is_sysrange_done(VL53L0X_IDX_MID)) {
+            // Sanity check!
+            ASSERT(false);
+        }
+
+        result = vl53l0x_read_range(VL53L0X_IDX_MID, &latest_ranges[VL53L0X_IDX_MID]);
+        if (result) {
+            return result;
+        }
+#if defined(JR)
+        result = vl53l0x_read_range(VL53L0X_IDX_LEFT, &latest_ranges[VL53L0X_IDX_LEFT]);
+        if (result) {
+            return result;
+        }
+        result = vl53l0x_read_range(VL53L0X_IDX_RIGHT, &latest_ranges[VL53L0X_IDX_RIGHT]);
+        if (result) {
+            return result;
+        }
+#endif
+        result = vl53l0x_start_measuring_multiple();
+        if (result) {
+            return result;
+        }
+        *fresh_values = true;
+    } else {
+        *fresh_values = false;
+    }
+    for (int i = 0; i < VL53L0X_IDX_COUNT; i++) {
+        ranges[i] = latest_ranges[i];
+    }
+    return result;
+}
+
+vl53l0x_result_e vl53l0x_init(void)
+{
+    ASSERT(!initialized);
+
+    // TODO: Tune this delay (required to make the VL53L0X communication work)
+    __delay_cycles(3000);
+
+    i2c_init();
+
+    vl53l0x_result_e result = vl53l0x_init_addresses();
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_init_config(VL53L0X_IDX_MID);
+    if (result) {
+        return result;
+    }
+#if defined(JR)
+    result = vl53l0x_init_config(VL53L0X_IDX_LEFT);
+    if (result) {
+        return result;
+    }
+    result = vl53l0x_init_config(VL53L0X_IDX_RIGHT);
+    if (result) {
+        return result;
+    }
+#endif
+    initialized = true;
+    return VL53L0X_RESULT_OK;
+}

--- a/src/drivers/vl53l0x.h
+++ b/src/drivers/vl53l0x.h
@@ -1,0 +1,57 @@
+#ifndef VL53L0X_H
+#define VL53L0X_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define VL53L0X_OUT_OF_RANGE (8190)
+
+typedef enum {
+    VL53L0X_IDX_MID,
+    VL53L0X_IDX_LEFT,
+    VL53L0X_IDX_RIGHT,
+    VL53L0X_IDX_COUNT
+} vl53l0x_idx_e;
+
+typedef enum {
+    VL53L0X_RESULT_OK,
+    VL53L0X_RESULT_ERROR_I2C,
+    VL53L0X_RESULT_ERROR_BOOT,
+    VL53L0X_RESULT_ERROR_SPAD,
+    VL53L0X_RESULT_ERROR_MEASURE_ONGOING,
+} vl53l0x_result_e;
+
+typedef uint16_t vl53l0x_ranges_t[VL53L0X_IDX_COUNT];
+
+/**
+ * Initializes the sensors in the vl53l0x_idx_e enum.
+ * @note Each sensor must have its XSHUT pin connected.
+ */
+vl53l0x_result_e vl53l0x_init(void);
+
+/**
+ * Does a single range measurement (starts and polls until it's finished)
+ * @param idx selects specific sensor
+ * @param range contains the measured range or VL53L0X_OUT_OF_RANGE
+ *        if out of range.
+ * @return see vl53l0x_result_e
+ * @note   Polling
+ */
+vl53l0x_result_e vl53l0x_read_range_single(vl53l0x_idx_e idx, uint16_t *range);
+
+/**
+ * Reads all sensors. This is faster than reading sensors individually because
+ * we do the measures in parallel. It starts measuring if no measurement is ongoing
+ * and will return cached values if the measuring is not finished.
+ * @param ranges contains the measured ranges (or VL53L0X_OUT_OF_RANGE
+ *        if out of range).
+ * @param fresh_values is true if the values are from a new measurement and
+ *        false if cached values.
+ * @return see vl53l0x_result_e
+ * @note Blocks until range measurement is done when called the first time (unless
+ *       vl53l0x_start_measuring_multiple has been called)
+ * @note Returns values from the last measurement if measuring is not finished
+ */
+vl53l0x_result_e vl53l0x_read_range_multiple(vl53l0x_ranges_t ranges, bool *fresh_values);
+
+#endif // VL53L0X_H

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -12,6 +12,7 @@
 #include "../drivers/vl53l0x.h"
 #include "../app/drive.h"
 #include "../app/line.h"
+#include "../app/enemy.h"
 #include "../common/assert_handler.h"
 #include "../common/defines.h"
 #include "../common/trace.h"
@@ -450,6 +451,19 @@ static void test_vl53l0x_mult(void)
         TRACE("Range measure mid: %u, left: %u, right: %u", ranges[VL53L0X_IDX_MID],
                                                             ranges[VL53L0X_IDX_LEFT],
                                                             ranges[VL53L0X_IDX_RIGHT]);
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_enemy(void)
+{
+    test_setup();
+    trace_init();
+    enemy_init();
+    while (1) {
+        struct enemy enemy = enemy_get();
+        TRACE("%s %s", enemy_pos_str(enemy.position), enemy_range_str(enemy.range));
         BUSY_WAIT_ms(1000);
     }
 }

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -9,6 +9,7 @@
 #include "../drivers/adc.h"
 #include "../drivers/qre1113.h"
 #include "../drivers/i2c.h"
+#include "../drivers/vl53l0x.h"
 #include "../app/drive.h"
 #include "../app/line.h"
 #include "../common/assert_handler.h"
@@ -398,6 +399,58 @@ static void test_i2c(void)
         
         BUSY_WAIT_ms(1000);
 
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_vl53l0x(void)
+{
+    test_setup();
+    trace_init();
+    vl53l0x_result_e result = vl53l0x_init();
+    if (result) {
+        TRACE("vl53l0x_init failed");
+    }
+
+    while(1) {
+        uint16_t range = 0;
+        result = vl53l0x_read_range_single(VL53L0X_IDX_MID, &range);
+        if (result) {
+            TRACE("VL53L0X Error: %u", result);
+        } else {
+            if (range != VL53L0X_OUT_OF_RANGE) {
+                TRACE("Range %u mm", range);
+            } else {
+                TRACE("Out of Range");
+            }
+        }
+        BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_vl53l0x_mult(void)
+{
+    test_setup();
+    trace_init();
+    vl53l0x_result_e result = vl53l0x_init();
+    if (result) {
+        TRACE("vl53l0x_init failed");
+    } else {
+        TRACE("vl53l0x_init successful");
+    }
+
+    while (1) {
+        vl53l0x_ranges_t ranges = {0, 0, 0};
+        bool fresh_values = false;
+        result = vl53l0x_read_range_multiple(ranges, &fresh_values);
+        if (result) {
+            TRACE("Mult VL53L0x Error: %u", result);
+        }
+        TRACE("Range measure mid: %u, left: %u, right: %u", ranges[VL53L0X_IDX_MID],
+                                                            ranges[VL53L0X_IDX_LEFT],
+                                                            ranges[VL53L0X_IDX_RIGHT]);
+        BUSY_WAIT_ms(1000);
     }
 }
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -8,6 +8,7 @@
 #include "../drivers/tb6612fng.h"
 #include "../drivers/adc.h"
 #include "../drivers/qre1113.h"
+#include "../drivers/i2c.h"
 #include "../app/drive.h"
 #include "../app/line.h"
 #include "../common/assert_handler.h"
@@ -352,6 +353,51 @@ static void test_line(void)
     while(1) {
         TRACE("line %u", line_get());
         BUSY_WAIT_ms(1000);
+    }
+}
+
+SUPPRESS_UNUSED
+static void test_i2c(void)
+{
+    test_setup();
+    trace_init();
+    i2c_init();
+    
+    /* Specific to VL53L0X sensor */
+    io_set_out(IO_XSHUT_MID, IO_OUT_HIGH); // Leave standby
+    i2c_set_slave_address(0x29); // Default Address 
+    BUSY_WAIT_ms(100); // Wait for VL53L0X to leave standby
+    
+    while(1) {
+        uint8_t vl53l0x_id = 0;
+        i2c_result_e result = i2c_read_addr8_data8(0xC0, &vl53l0x_id);
+        if (result) {
+            TRACE("Read Error: %d", result);
+        } else {
+            if (vl53l0x_id == 0xEE) {
+                TRACE("Succesful Read: VL53L0X id is 0xEE");
+            } else {
+                TRACE("Read Error: Read unexpected VL53L0X id 0x%X", vl53l0x_id);
+            }
+        }
+        BUSY_WAIT_ms(1000);
+
+        const uint8_t write_value = 0xAB;
+        result = i2c_write_addr8_data8(0x01, write_value);
+        if (result) {
+            TRACE("Write Error: %d", result);
+        }
+
+        uint8_t read_value = 0;
+        result = i2c_read_addr8_data8(0x01, &read_value);
+        if (read_value == write_value) {
+            TRACE("Succesful Write: Register 0x01");
+        } else {
+            TRACE("Write Error: Expected 0x%X, got 0x%X", write_value, read_value);
+        }
+        
+        BUSY_WAIT_ms(1000);
+
     }
 }
 


### PR DESCRIPTION
The range sensor (VL53L0X) come with a i2c interface. Configure the i2c pins and implement an i2c driver on the msp430 to talk to the range sensors. Use a standard polling method to make it simple, since there is nothing useful to do while waitng for the transmission. Verify the driver works by sending simple register writes/reads to the range sensor.

Alter the pin assignment because used pin 1.6 is the only pin available for the scl used by i2c. Also fix a bug in the UART driver, causing the uart_putchar_polling function to hang.